### PR TITLE
Implement unit tests and configure for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.6
+    working_directory: ~/calrissian
+    steps:
+      - checkout:
+          path: ~/calrissian
+      - restore_cache:
+          key: v1-dependency-cache-{{ checksum "requirements.txt" }}
+      - run:
+          name: install python dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+      - save_cache:
+          key: v1-dependency-cache-{{ checksum "requirements.txt" }}
+          paths:
+            - "venv"
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            nose2

--- a/calrissian/context.py
+++ b/calrissian/context.py
@@ -1,4 +1,4 @@
-from tool import calrissian_make_tool
+from calrissian.tool import calrissian_make_tool
 from cwltool.context import LoadingContext
 import logging
 

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -25,7 +25,15 @@ def k8s_safe_name(name):
     :param name:
     :return: a safe name
     """
-    return name.replace('_', '-')
+    return name.lower().replace('_', '-')
+
+
+# TODO: fetch these from the kubernetes API since they are attached to this pod
+def populate_demo_volume_builder_entries(volume_builder):
+    volume_builder.add_persistent_volume_entry('/calrissian/input-data', 'calrissian-input-data')
+    volume_builder.add_persistent_volume_entry('/calrissian/output-data', 'calrissian-output-data')
+    volume_builder.add_persistent_volume_entry('/calrissian/tmptmp', 'calrissian-tmp')
+    volume_builder.add_persistent_volume_entry('/calrissian/tmpout', 'calrissian-tmpout')
 
 
 class KubernetesVolumeBuilder(object):
@@ -34,14 +42,6 @@ class KubernetesVolumeBuilder(object):
         self.persistent_volume_entries = {}
         self.volume_mounts = []
         self.volumes = []
-        self.populate_demo_values()
-
-    def populate_demo_values(self):
-        # TODO: fetch these from the kubernetes API since they are attached to this pod
-        self.add_persistent_volume_entry('/calrissian/input-data', 'calrissian-input-data')
-        self.add_persistent_volume_entry('/calrissian/output-data', 'calrissian-output-data')
-        self.add_persistent_volume_entry('/calrissian/tmptmp', 'calrissian-tmp')
-        self.add_persistent_volume_entry('/calrissian/tmpout', 'calrissian-tmpout')
 
     def add_persistent_volume_entry(self, prefix, claim_name):
         entry = {
@@ -73,7 +73,7 @@ class KubernetesVolumeBuilder(object):
     def random_tag(length=8):
         return ''.join(random.choices(string.ascii_lowercase, k=length))
 
-    def add_volume_binding(self, base_name, source, target, note, writable):
+    def add_volume_binding(self, source, target, writable):
         # Find the persistent volume claim where this goes
         pv = self.find_persistent_volume(source)
         if not pv:
@@ -186,7 +186,9 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
     def __init__(self, *args, **kwargs):
         super(CalrissianCommandLineJob, self).__init__(*args, **kwargs)
         self.client = KubernetesClient()
-        self.volume_builder = KubernetesVolumeBuilder()
+        volume_builder = KubernetesVolumeBuilder()
+        volume_builder.populate_demo_values()
+        self.volume_builder = volume_builder
 
     def make_tmpdir(self):
         # Doing this because cwltool.job does it
@@ -226,9 +228,9 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
         runtime = []
 
         # Append volume for outdir
-        self._add_volume_binding(os.path.realpath(self.outdir), self.builder.outdir, 'outdir', writable=True)
+        self._add_volume_binding(os.path.realpath(self.outdir), self.builder.outdir, writable=True)
         # Append volume for tmp
-        self._add_volume_binding(os.path.realpath(self.tmpdir), '/tmp', 'tmp', writable=True)
+        self._add_volume_binding(os.path.realpath(self.tmpdir), '/tmp', writable=True)
 
         # Call the ContainerCommandLineJob add_volumes method
         self.add_volumes(self.pathmapper,
@@ -274,8 +276,8 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
     def execute_kubernetes_job(self, k8s_job):
         self.client.submit_job(k8s_job)
 
-    def _add_volume_binding(self, source, target, note='vol', writable=False):
-        self.volume_builder.add_volume_binding(self.name, source, target, note, writable)
+    def _add_volume_binding(self, source, target, writable=False):
+        self.volume_builder.add_volume_binding(source, target, writable)
 
     # Below are concrete implementations of methods called by add_volumes
     # They are based on https://github.com/common-workflow-language/cwltool/blob/1.0.20181201184214/cwltool/docker.py

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -138,7 +138,7 @@ class KubernetesJobBuilder(object):
         :return: array of env variables to set
         """
         environment = []
-        for name, value in self.environment.items():
+        for name, value in sorted(self.environment.items()):
             environment.append({'name': name, 'value': value})
         return environment
 

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -187,7 +187,7 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
         super(CalrissianCommandLineJob, self).__init__(*args, **kwargs)
         self.client = KubernetesClient()
         volume_builder = KubernetesVolumeBuilder()
-        volume_builder.populate_demo_values()
+        populate_demo_volume_builder_entries(volume_builder)
         self.volume_builder = volume_builder
 
     def make_tmpdir(self):

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -1,6 +1,6 @@
 from cwltool.job import ContainerCommandLineJob
 from cwltool.utils import DEFAULT_TMP_PREFIX
-from k8s import KubernetesClient
+from calrissian.k8s import KubernetesClient
 import logging
 import os
 import yaml

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -32,44 +32,45 @@ class CalrissianJobException(Exception):
 
 class KubernetesClient(object):
     def __init__(self):
-        self.job_ids = []  # This really only applies to one job, so should probably update that
+        self.job_uid = None
         # load_config must happen before instantiating client
         self.namespace = load_config_get_namespace()
         self.batch_api_instance = client.BatchV1Api()
 
-    def _job_started(self, job):
+    def _watching_job(self, job):
+        return self.job_uid == job.metadata.uid
+
+    def watch_job(self, job):
         log.info('k8s job \'{}\' started'.format(job.metadata.name))
-        self.job_ids.append(job.metadata.uid)
+        if self.job_uid is not None:
+            raise CalrissianJobException('This client is already observing job {}'.format(self.job_uid))
+        self.job_uid = job.metadata.uid
 
     def _job_succeeded(self, job):
         log.info('k8s job \'{}\' succeeded'.format(job.metadata.name))
-        self.job_ids.remove(job.metadata.uid)
+        self.job_uid = None
 
     def _job_failed(self, job):
         log.info('k8s job \'{}\' failed'.format(job.metadata.name))
-        self.job_ids.remove(job.metadata.uid)
+        self.job_uid = None
         raise CalrissianJobException('Job failed')
-
-    def _done_waiting(self):
-        return len(self.job_ids) == 0
 
     def submit_job(self, job_body):
         # submit the job
         job = self.batch_api_instance.create_namespaced_job(self.namespace, job_body)
         log.info('Created k8s job name {} with id {}'.format(job.metadata.name, job.metadata.uid))
-        self._job_started(job)
+        self.watch_job(job)
 
     def wait(self):
         w = watch.Watch()
         for event in w.stream(self.batch_api_instance.list_namespaced_job, self.namespace):
             job = event['object']
-            if job.metadata.uid not in self.job_ids:
-                # Not a job we're looking for
+            if not self._watching_job(job):
+                # Not the job we're looking for
                 continue
             if job.status.succeeded:
                 self._job_succeeded(job)
+                w.stop() # stop watching for events, our job is done
+                self.batch_api_instance.delete_namespaced_job(job.metadata.name, self.namespace, body=client.V1DeleteOptions())
             if job.status.failed:
                 self._job_failed(job)
-            if self._done_waiting():
-                self.batch_api_instance.delete_namespaced_job(job.metadata.name, self.namespace, body=client.V1DeleteOptions())
-                w.stop()

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -31,9 +31,8 @@ class CalrissianJobException(Exception):
 
 
 class KubernetesClient(object):
-
     def __init__(self):
-        self.job_ids = []
+        self.job_ids = []  # This really only applies to one job, so should probably update that
         # load_config must happen before instantiating client
         self.namespace = load_config_get_namespace()
         self.batch_api_instance = client.BatchV1Api()

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -1,6 +1,6 @@
-from executor import CalrissianExecutor
-from context import CalrissianLoadingContext
-from version import version
+from calrissian.executor import CalrissianExecutor
+from calrissian.context import CalrissianLoadingContext
+from calrissian.version import version
 from cwltool.main import main as cwlmain
 from cwltool.argparser import arg_parser
 import logging

--- a/calrissian/tool.py
+++ b/calrissian/tool.py
@@ -1,6 +1,6 @@
 from cwltool.command_line_tool import CommandLineTool
 from cwltool.workflow import default_make_tool
-from job import CalrissianCommandLineJob
+from calrissian.job import CalrissianCommandLineJob
 import logging
 
 log = logging.getLogger("calrissian.tool")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ cachetools==3.0.0
 certifi==2018.11.29
 cffi==1.11.5
 chardet==3.0.4
+coverage==4.5.2
 cryptography==2.4.2
 cwltool==1.0.20181217162649
 decorator==4.3.0
@@ -18,6 +19,7 @@ lxml==4.2.5
 mistune==0.8.4
 mypy-extensions==0.4.1
 networkx==2.2
+nose2==0.8.0
 oauthlib==2.1.0
 prov==1.5.1
 psutil==5.4.8

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-python calrissian/main.py \
+python -m calrissian.main \
   --tmpdir-prefix /calrissian/tmptmp/ \
   --tmp-outdir-prefix /calrissian/tmpout/ \
   --outdir /calrissian/output-data \

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+nose2

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,11 @@
+from unittest import TestCase, mock
+from calrissian.context import CalrissianLoadingContext
+
+
+class ContextTestCase(TestCase):
+
+    @mock.patch('calrissian.context.calrissian_make_tool')
+    def test_uses_calrissian_make_tool(self, mock_make_tool):
+        ctx = CalrissianLoadingContext()
+        self.assertEqual(ctx.construct_tool_object, mock_make_tool)
+

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -2,10 +2,9 @@ from unittest import TestCase, mock
 from calrissian.context import CalrissianLoadingContext
 
 
-class ContextTestCase(TestCase):
+class CalrissianLoadingContextTestCase(TestCase):
 
     @mock.patch('calrissian.context.calrissian_make_tool')
     def test_uses_calrissian_make_tool(self, mock_make_tool):
         ctx = CalrissianLoadingContext()
         self.assertEqual(ctx.construct_tool_object, mock_make_tool)
-

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,10 +1,11 @@
-from unittest import TestCase, mock
+from unittest import TestCase
+from unittest.mock import patch
 from calrissian.context import CalrissianLoadingContext
 
 
 class CalrissianLoadingContextTestCase(TestCase):
 
-    @mock.patch('calrissian.context.calrissian_make_tool')
+    @patch('calrissian.context.calrissian_make_tool')
     def test_uses_calrissian_make_tool(self, mock_make_tool):
         ctx = CalrissianLoadingContext()
         self.assertEqual(ctx.construct_tool_object, mock_make_tool)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,4 +1,4 @@
-from unittest import TestCase, mock
+from unittest import TestCase
 from calrissian.executor import CalrissianExecutor
 
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,0 +1,9 @@
+from unittest import TestCase, mock
+from calrissian.executor import CalrissianExecutor
+
+
+class CalrissianExecutorTestCase(TestCase):
+
+    def test_init(self):
+        e = CalrissianExecutor()
+        self.assertIsNotNone(e)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
-from unittest.mock import Mock
+from unittest.mock import Mock, patch, call
 from calrissian.job import k8s_safe_name, KubernetesVolumeBuilder, VolumeBuilderException, KubernetesJobBuilder
+from calrissian.job import CalrissianCommandLineJob
 
 
 class SafeNameTestCase(TestCase):
@@ -135,3 +136,204 @@ class KubernetesJobBuilderTestCase(TestCase):
             }
         }
         self.assertEqual(expected, self.job_builder.build())
+
+
+@patch('calrissian.job.KubernetesClient')
+@patch('calrissian.job.KubernetesVolumeBuilder')
+class CalrissianCommandLineJobTestCase(TestCase):
+
+    def setUp(self):
+        self.builder = Mock(outdir='/out')
+        self.joborder = Mock()
+        self.make_path_mapper = Mock()
+        self.requirements = [{'class': 'DockerRequirement', 'dockerPull': 'dockerimage:1.0'}]
+        self.hints = []
+        self.name = 'test-clj'
+
+    def make_job(self):
+        return CalrissianCommandLineJob(self.builder, self.joborder, self.make_path_mapper, self.requirements,
+                                       self.hints, self.name)
+
+    def test_init(self, mock_volume_builder, mock_client):
+        job = self.make_job()
+        self.assertTrue(mock_client.called)
+        self.assertTrue(mock_volume_builder.called)
+        self.assertTrue(mock_volume_builder.return_value.populate_demo_values.called)
+        self.assertEqual(job.client, mock_client.return_value)
+        self.assertEqual(job.volume_builder, mock_volume_builder.return_value)
+        self.assertEqual(job.name, self.name)
+
+    @patch('calrissian.job.os')
+    def test_makes_tmpdir_when_not_exists(self, mock_os, mock_volume_builder, mock_client):
+        mock_os.path.exists.return_value = False
+        job = self.make_job()
+        job.make_tmpdir()
+        self.assertTrue(mock_os.path.exists.called)
+        self.assertTrue(mock_os.makedirs.called_with(job.tmpdir))
+
+    @patch('calrissian.job.os')
+    def test_not_make_tmpdir_when_exists(self, mock_os, mock_volume_builder, mock_client):
+        mock_os.path.exists.return_value = True
+        job = self.make_job()
+        job.make_tmpdir()
+        self.assertTrue(mock_os.path.exists.called)
+        self.assertFalse(mock_os.makedirs.called)
+
+    def test_populate_env_vars(self, mock_volume_builder, mock_client):
+        job = self.make_job()
+        job.populate_env_vars()
+        # tmpdir should be '/tmp'
+        self.assertEqual(job.environment['TMPDIR'], '/tmp')
+        # home should be builder.outdir
+        self.assertEqual(job.environment['HOME'], '/out')
+
+    def test_wait_for_kubernetes_job(self, mock_volume_builder, mock_client):
+        job = self.make_job()
+        job.wait_for_kubernetes_job()
+        self.assertTrue(mock_client.return_value.wait.called)
+
+    def test_finish_calls_output_callback_with_status(self, mock_volume_builder, mock_client):
+        job = self.make_job()
+        mock_collected_outputs = Mock()
+        job.collect_outputs = Mock()
+        job.collect_outputs.return_value = mock_collected_outputs
+        job.output_callback = Mock()
+        job.finish()
+        self.assertTrue(job.collect_outputs.called)
+        job.output_callback.assert_called_with(mock_collected_outputs, 'success')
+
+    def test__get_container_image(self, mock_volume_builder, mock_client):
+        job = self.make_job()
+        image = job._get_container_image()
+        self.assertEqual(image, 'dockerimage:1.0')
+
+    @patch('calrissian.job.KubernetesJobBuilder')
+    @patch('calrissian.job.os')
+    def test_create_kubernetes_runtime(self, mock_os, mock_job_builder, mock_volume_builder, mock_client):
+        def realpath(path):
+            return '/real' + path
+        mock_os.path.realpath = realpath
+        mock_add_volume_binding = Mock()
+        mock_volume_builder.return_value.add_volume_binding = mock_add_volume_binding
+
+        mock_job_builder.return_value.build.return_value = '<built job>'
+        job = self.make_job()
+        job.outdir = '/outdir'
+        job.tmpdir = '/tmpdir'
+        mock_runtime_context = Mock(tmpdir_prefix='TP')
+        built = job.create_kubernetes_runtime(mock_runtime_context)
+        # Adds volume binding for outdir
+        # Adds volume binding for /tmp
+        self.assertEqual(mock_add_volume_binding.call_args_list,
+                         [call('/real/outdir', '/out', True),
+                          call('/real/tmpdir', '/tmp', True)])
+        # looks at generatemapper
+        # creates a KubernetesJobBuilder
+        self.assertEqual(mock_job_builder.call_args, call(
+            job.name,
+            job._get_container_image(),
+            job.environment,
+            job.volume_builder.volume_mounts,
+            job.volume_builder.volumes,
+            job.command_line,
+            job.stdout,
+            job.stderr,
+            job.stdin
+        ))
+        # calls builder.build
+        self.assertTrue(mock_job_builder.return_value.build.called)
+        # returns that
+        self.assertEqual(built, mock_job_builder.return_value.build.return_value)
+
+    def test_execute_kubernetes_job(self, mock_volume_builder, mock_client):
+        job = self.make_job()
+        k8s_job = Mock()
+        job.execute_kubernetes_job(k8s_job)
+        self.assertTrue(mock_client.return_value.submit_job.called_with(k8s_job))
+
+    def test_add_file_or_directory_volume_ro(self, mock_volume_builder, mock_client):
+        mock_add_volume_binding = mock_volume_builder.return_value.add_volume_binding
+        job = self.make_job()
+        runtime = []
+        volume = Mock(resolved='/resolved', target='/target')
+        job.add_file_or_directory_volume(runtime, volume, None)
+        # It should add the volume binding with writable=False
+        self.assertEqual(mock_add_volume_binding.call_args, call('/resolved', '/target', False))
+
+    def test_ignores_add_file_or_directory_volume_with_under_colon(self, mock_volume_builder, mock_client):
+        mock_add_volume_binding = mock_volume_builder.return_value.add_volume_binding
+        job = self.make_job()
+        runtime = []
+        volume = Mock(resolved='_:/resolved', target='/target')
+        job.add_file_or_directory_volume(runtime, volume, None)
+        self.assertFalse(mock_add_volume_binding.called)
+
+    def test_add_writable_file_volume_inplace(self, mock_volume_builder, mock_client):
+        mock_add_volume_binding = mock_volume_builder.return_value.add_volume_binding
+        job = self.make_job()
+        job.inplace_update = True
+        runtime = []
+        volume = Mock(resolved='/resolved', target='/target')
+        job.add_writable_file_volume(runtime, volume, None, None)
+        # with inplace, the binding should be added with writable=True
+        self.assertEqual(mock_add_volume_binding.call_args, call('/resolved', '/target', True))
+
+    @patch('calrissian.job.shutil')
+    @patch('calrissian.job.ensure_writable')
+    def test_add_writable_file_volume_host_outdir_tgt(self, mock_ensure_writable, mock_shutil, mock_volume_builder, mock_client):
+        mock_shutil.copy = Mock()
+        mock_add_volume_binding = mock_volume_builder.return_value.add_volume_binding
+        job = self.make_job()
+        runtime = []
+        volume = Mock(resolved='/resolved', target='/target')
+        # In this case, the target is a host outdir, so we do not add a volume mapping
+        # but instead just copy the file there and ensure it is writable
+        job.add_writable_file_volume(runtime, volume, '/host-outdir-tgt', None)
+        self.assertFalse(mock_add_volume_binding.called)
+        self.assertEqual(mock_shutil.copy.call_args, call('/resolved', '/host-outdir-tgt'))
+        self.assertEqual(mock_ensure_writable.call_args, call('/host-outdir-tgt'))
+
+    @patch('calrissian.job.tempfile')
+    @patch('calrissian.job.shutil')
+    @patch('calrissian.job.ensure_writable')
+    def test_add_writable_file_volumehost_not_outdir_tgt(self, mock_ensure_writable, mock_shutil, mock_tempfile, mock_volume_builder, mock_client):
+        mock_shutil.copy = Mock()
+        mock_tempfile.mkdtemp.return_value = '/mkdtemp-dir'
+        mock_add_volume_binding = mock_volume_builder.return_value.add_volume_binding
+        job = self.make_job()
+        runtime = []
+        volume = Mock(resolved='/resolved', target='/target')
+        job.add_writable_file_volume(runtime, volume, None, None)
+        # When writable but not inplace, we expect a copy
+        # And when not host-outdir-tgt, we expect that copy in a tmpdir
+        self.assertEqual(mock_tempfile.mkdtemp.call_args, call(dir=job.tmpdir))
+        self.assertEqual(mock_shutil.copy.call_args, call('/resolved', '/mkdtemp-dir/resolved'))
+        # and we expect add_volume_binding called with the tempdir copy
+        self.assertEqual(mock_add_volume_binding.call_args, call('/mkdtemp-dir/resolved', '/target', True))
+        # We also expect ensure_writable to be called on the copy in mkdtemp-dir
+        self.assertEqual(mock_ensure_writable.call_args, call('/mkdtemp-dir/resolved'))
+
+    def test_add_writable_directory_volume(self, mock_volume_builder, mock_client):
+        # These were ported over from cwltool but are not used by our workflows
+        # and can be tested later
+        pass
+
+    def test_run(self, mock_volume_builder, mock_client):
+        job = self.make_job()
+        job.make_tmpdir = Mock()
+        job.populate_env_vars = Mock()
+        job._setup = Mock()
+        job.create_kubernetes_runtime = Mock()
+        job.execute_kubernetes_job = Mock()
+        job.wait_for_kubernetes_job = Mock()
+        job.finish = Mock()
+
+        runtimeContext = Mock()
+        job.run(runtimeContext)
+        self.assertTrue(job.make_tmpdir.called)
+        self.assertTrue(job.populate_env_vars.called)
+        self.assertEqual(job._setup.call_args, call(runtimeContext))
+        self.assertEqual(job.create_kubernetes_runtime.call_args, call(runtimeContext))
+        self.assertEqual(job.execute_kubernetes_job.call_args, call(job.create_kubernetes_runtime.return_value))
+        self.assertTrue(job.wait_for_kubernetes_job.called)
+        self.assertTrue(job.finish.called)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -12,6 +12,7 @@ class SafeNameTestCase(TestCase):
         made_safe = k8s_safe_name(self.unsafe_name)
         self.assertEqual(self.safe_name, made_safe)
 
+
 class KubernetesVolumeBuilderTestCase(TestCase):
 
     def setUp(self):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -154,11 +154,12 @@ class CalrissianCommandLineJobTestCase(TestCase):
         return CalrissianCommandLineJob(self.builder, self.joborder, self.make_path_mapper, self.requirements,
                                        self.hints, self.name)
 
-    def test_init(self, mock_volume_builder, mock_client):
+    @patch('calrissian.job.populate_demo_volume_builder_entries')
+    def test_init(self, mock_populate_demo_volume_builder_entries, mock_volume_builder, mock_client):
         job = self.make_job()
         self.assertTrue(mock_client.called)
         self.assertTrue(mock_volume_builder.called)
-        self.assertTrue(mock_volume_builder.return_value.populate_demo_values.called)
+        self.assertTrue(mock_populate_demo_volume_builder_entries.called)
         self.assertEqual(job.client, mock_client.return_value)
         self.assertEqual(job.volume_builder, mock_volume_builder.return_value)
         self.assertEqual(job.name, self.name)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,0 +1,58 @@
+from unittest import TestCase, mock
+from calrissian.job import k8s_safe_name, KubernetesVolumeBuilder, VolumeBuilderException
+
+
+class SafeNameTestCase(TestCase):
+
+    def setUp(self):
+        self.unsafe_name = 'Wine_1234'
+        self.safe_name = 'wine-1234'
+
+    def test_makes_name_safe(self):
+        made_safe = k8s_safe_name(self.unsafe_name)
+        self.assertEqual(self.safe_name, made_safe)
+
+class KubernetesVolumeBuilderTestCase(TestCase):
+
+    def setUp(self):
+        self.volume_builder = KubernetesVolumeBuilder()
+
+    def test_finds_persistent_volume(self):
+        self.volume_builder.add_persistent_volume_entry('/prefix/1', 'claim1')
+        self.assertIsNotNone(self.volume_builder.find_persistent_volume('/prefix/1f'))
+        self.assertIsNone(self.volume_builder.find_persistent_volume('/notfound'))
+
+    def test_calculates_subpath(self):
+        self.volume_builder.add_persistent_volume_entry('/prefix/1', 'claim1')
+        subpath = KubernetesVolumeBuilder.calculate_subpath('/prefix/1/foo', '/prefix/1')
+        self.assertEqual('foo', subpath)
+
+    def test_random_tag(self):
+        random_tag = KubernetesVolumeBuilder.random_tag(8)
+        self.assertEqual(len(random_tag), 8)
+
+    def test_add_rw_volume_binding(self):
+        self.assertEqual(0, len(self.volume_builder.volumes))
+        self.volume_builder.add_persistent_volume_entry('/prefix/1', 'claim1')
+        self.assertEqual({'name':'claim1', 'persistentVolumeClaim': {'claimName': 'claim1'}}, self.volume_builder.volumes[0])
+
+        self.assertEqual(0, len(self.volume_builder.volume_mounts))
+        self.volume_builder.add_volume_binding('/prefix/1/input1', '/input1-target', True)
+        self.assertEqual({'name': 'claim1', 'mountPath': '/input1-target', 'readOnly': False, 'subPath': 'input1'}, self.volume_builder.volume_mounts[0])
+
+    def test_add_ro_volume_binding(self):
+        # read-only
+        self.assertEqual(0, len(self.volume_builder.volumes))
+        self.volume_builder.add_persistent_volume_entry('/prefix/2', 'claim2')
+        self.assertEqual({'name':'claim2', 'persistentVolumeClaim': {'claimName': 'claim2'}}, self.volume_builder.volumes[0])
+
+        self.assertEqual(0, len(self.volume_builder.volume_mounts))
+        self.volume_builder.add_volume_binding('/prefix/2/input2', '/input2-target', False)
+        self.assertEqual({'name': 'claim2', 'mountPath': '/input2-target', 'readOnly': True, 'subPath': 'input2'}, self.volume_builder.volume_mounts[0])
+
+    def test_volume_binding_exception_if_not_found(self):
+        self.assertEqual(0, len(self.volume_builder.volumes))
+        with self.assertRaises(VolumeBuilderException):
+            self.volume_builder.add_volume_binding('/prefix/2/input2', '/input2-target', False)
+
+

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+from unittest.mock import Mock, patch
+from calrissian.k8s import load_config_get_namespace, KubernetesClient
+
+
+@patch('calrissian.k8s.read_file')
+@patch('calrissian.k8s.config')
+class LoadConfigTestCase(TestCase):
+
+    def test_load_config_get_namespace_incluster(self, mock_config, mock_read_file):
+        mock_read_file.return_value = 'in-cluster-namespace'
+        namespace = load_config_get_namespace()
+        self.assertEqual(namespace, 'in-cluster-namespace')
+        self.assertTrue(mock_read_file.called)
+        self.assertTrue(mock_config.load_incluster_config.called)
+        self.assertFalse(mock_config.load_kube_config.called)
+
+    def test_load_config_get_namespace_external(self, mock_config, mock_read_file):
+        # When load_incluster_config raises an exception, call load_kube_config and assume 'default'
+        mock_config.ConfigException = Exception
+        mock_config.load_incluster_config.side_effect = Exception
+        namespace = load_config_get_namespace()
+        self.assertEqual(namespace, 'default')
+        self.assertFalse(mock_read_file.called)
+        self.assertTrue(mock_config.load_incluster_config.called)
+        self.assertTrue(mock_config.load_kube_config.called)
+

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
-from unittest.mock import Mock, patch
-from calrissian.k8s import load_config_get_namespace, KubernetesClient
+from unittest.mock import Mock, patch, call
+from calrissian.k8s import load_config_get_namespace, KubernetesClient, CalrissianJobException
 
 
 @patch('calrissian.k8s.read_file')
@@ -24,4 +24,77 @@ class LoadConfigTestCase(TestCase):
         self.assertFalse(mock_read_file.called)
         self.assertTrue(mock_config.load_incluster_config.called)
         self.assertTrue(mock_config.load_kube_config.called)
+
+
+@patch('calrissian.k8s.client')
+@patch('calrissian.k8s.load_config_get_namespace')
+class KubernetesClientTestCase(TestCase):
+
+    def test_init(self, mock_get_namespace, mock_client):
+        kc = KubernetesClient()
+        self.assertEqual(kc.namespace, mock_get_namespace.return_value)
+        self.assertEqual(kc.batch_api_instance, mock_client.BatchV1Api.return_value)
+
+    def test_submit_job(self, mock_get_namespace, mock_client):
+        mock_get_namespace.return_value = 'namespace'
+        mock_create_namespaced_job = Mock()
+        mock_create_namespaced_job.return_value = Mock(metadata=Mock(uid='123'))
+        mock_client.BatchV1Api.return_value.create_namespaced_job = mock_create_namespaced_job
+        kc = KubernetesClient()
+        self.assertEqual(len(kc.job_ids), 0)
+        mock_body = Mock()
+        kc.submit_job(mock_body)
+        self.assertEqual(mock_create_namespaced_job.call_args, call('namespace', mock_body))
+        self.assertEqual(kc.job_ids, ['123'])
+
+    def setup_mock_watch(self, mock_watch, event):
+        mock_stream = Mock()
+        mock_stop = Mock()
+        mock_stream.return_value = [{'object': event}]
+        mock_watch.Watch.return_value.stream = mock_stream
+        mock_watch.Watch.return_value.stop = mock_stop
+
+    @patch('calrissian.k8s.watch')
+    def test_wait_successful_job(self, mock_watch, mock_get_namespace, mock_client):
+        kc = KubernetesClient()
+        kc.job_ids.append('456')
+        self.assertEqual(len(kc.job_ids), 1)
+        success_job_event = Mock(status=Mock(succeeded=True, failed=False), metadata=Mock(uid='456'))
+        self.setup_mock_watch(mock_watch, success_job_event)
+        kc.wait()
+        self.assertTrue(mock_watch.Watch.return_value.stream.called)
+        self.assertEqual(len(kc.job_ids), 0)
+        self.assertTrue(mock_watch.Watch.return_value.stop.called)
+        # job should be deleted
+        self.assertTrue(mock_client.BatchV1Api.return_value.delete_namespaced_job.called)
+
+    @patch('calrissian.k8s.watch')
+    def test_wait_failed_job_raises(self, mock_watch, mock_get_namespace, mock_client):
+        kc = KubernetesClient()
+        kc.job_ids.append('456')
+        self.assertEqual(len(kc.job_ids), 1)
+        failed_job_event = Mock(status=Mock(succeeded=False, failed=True), metadata=Mock(uid='456'))
+        self.setup_mock_watch(mock_watch, failed_job_event)
+        with self.assertRaises(CalrissianJobException):
+            kc.wait()
+        self.assertTrue(mock_watch.Watch.return_value.stream.called)
+        self.assertEqual(len(kc.job_ids), 0)
+        self.assertFalse(mock_watch.Watch.return_value.stop.called)
+        # job should not be deleted
+        self.assertFalse(mock_client.BatchV1Api.return_value.delete_namespaced_job.called)
+
+    @patch('calrissian.k8s.watch')
+    def test_ignores_other_job_ids(self, mock_watch, mock_get_namespace, mock_client):
+        kc = KubernetesClient()
+        kc.job_ids.append('456')
+        self.assertEqual(len(kc.job_ids), 1)
+        other_job_event = Mock(status=Mock(succeeded=True, failed=False), metadata=Mock(uid='789'))
+        self.setup_mock_watch(mock_watch, other_job_event)
+        kc.wait()
+        # None of kc's critical state should have changed
+        self.assertTrue(mock_watch.Watch.return_value.stream.called)
+        self.assertEqual(len(kc.job_ids), 1)
+        self.assertFalse(mock_watch.Watch.return_value.stop.called)
+        # job should not be deleted
+        self.assertFalse(mock_client.BatchV1Api.return_value.delete_namespaced_job.called)
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,0 +1,34 @@
+from unittest import TestCase
+from unittest.mock import Mock, patch, call
+from calrissian.tool import CalrissianCommandLineTool, calrissian_make_tool
+from calrissian.context import CalrissianLoadingContext
+
+
+class CalrissianMakeToolTestCase(TestCase):
+
+    @patch('calrissian.tool.CalrissianCommandLineTool')
+    def test_make_tool_clt(self, mock_calrissian_clt):
+        spec = {'class': 'CommandLineTool'}
+        loadingContext = CalrissianLoadingContext()
+        made_tool = calrissian_make_tool(spec, loadingContext)
+        self.assertEqual(made_tool, mock_calrissian_clt.return_value)
+        self.assertEqual(mock_calrissian_clt.call_args, call(spec, loadingContext))
+
+    @patch('calrissian.tool.default_make_tool')
+    def test_make_tool_default_make_tool(self, mock_default_make_tool):
+        spec = {'class': 'AnyOtherThing'}
+        loadingContext = Mock()
+        made_tool = calrissian_make_tool(spec, loadingContext)
+        self.assertEqual(made_tool, mock_default_make_tool.return_value)
+        self.assertEqual(mock_default_make_tool.call_args, call(spec, loadingContext))
+
+
+class CalrissianCommandLineToolTestCase(TestCase):
+
+    @patch('calrissian.tool.CalrissianCommandLineJob')
+    def test_make_job_runner(self, mock_command_line_job):
+        toolpath_object = {'id': '1', 'inputs': [], 'outputs': []}
+        loadingContext = CalrissianLoadingContext()
+        tool = CalrissianCommandLineTool(toolpath_object, loadingContext)
+        runner = tool.make_job_runner(Mock())
+        self.assertEqual(runner, mock_command_line_job)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,9 @@
+from unittest import TestCase
+from calrissian.version import version
+
+
+class VersionTestCase(TestCase):
+
+    def test_version(self):
+        self.assertEqual(version(), 'Calrissian-dev')
+


### PR DESCRIPTION
- Updates code to use absolute imports everywhere (this codebase is python 3 only)
- Refactors some functionality in volume builder for easier testing and future cleanup
- Simplifies k8s API client to only watch one job per instance
- Updates run.sh script to run main with `-m`

Fixes #3 