### PR TITLE
Add script to run tests with coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv
 cwl/tmp
 cwl/out
+.coverage

--- a/test-coverage.sh
+++ b/test-coverage.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+coverage run --source=calrissian -m nose2
+coverage report


### PR DESCRIPTION
Script to run tests under [coverage](https://coverage.readthedocs.io/en/v4.5.x/) and report code coverage in calrissian package