### PR TITLE
Improves CPU and memory accounting

### DIFF
--- a/calrissian/executor.py
+++ b/calrissian/executor.py
@@ -19,10 +19,6 @@ class CalrissianExecutor(MultithreadedJobExecutor):
         self.max_cores = max_cores
         log.debug('Initialized executor to allow {} MB RAM and {} CPU cores'.format(self.max_ram, self.max_cores))
 
-    def select_resources(self, request, runtime_context):
-        log.debug('CalrissianExecutor.select_resources: {}'.format(request))
-        return super(CalrissianExecutor, self).select_resources(request, runtime_context)
-
     def run_jobs(self,
                  process,           # type: Process
                  job_order_object,  # type: Dict[Text, Any]

--- a/calrissian/executor.py
+++ b/calrissian/executor.py
@@ -6,7 +6,18 @@ log = logging.getLogger("calrissian.executor")
 
 class CalrissianExecutor(MultithreadedJobExecutor):
 
-    # MultithreadedJobExecutor sets self.max_ram and self.max_cores to the local machine's resources
+    def __init__(self, max_ram, max_cores):  # type: () -> None
+        """
+        Initialize a Calrissian Executor
+        :param max_ram: Maximum RAM to use in megabytes
+        :param max_cores: Maximum number of CPU cores to use
+        """
+        # MultithreadedJobExecutor sets self.max_ram and self.max_cores to the local machine's resources using psutil.
+        # We can simply override these values after init, and the executor will use our provided values
+        super(CalrissianExecutor, self).__init__()
+        self.max_ram = max_ram
+        self.max_cores = max_cores
+        log.debug('Initialized executor to allow {} MB RAM and {} CPU cores'.format(self.max_ram, self.max_cores))
 
     def run_jobs(self,
                  process,           # type: Process

--- a/calrissian/executor.py
+++ b/calrissian/executor.py
@@ -19,10 +19,3 @@ class CalrissianExecutor(MultithreadedJobExecutor):
         self.max_cores = max_cores
         log.debug('Initialized executor to allow {} MB RAM and {} CPU cores'.format(self.max_ram, self.max_cores))
 
-    def run_jobs(self,
-                 process,           # type: Process
-                 job_order_object,  # type: Dict[Text, Any]
-                 logger,
-                 runtime_context     # type: RuntimeContext
-                ):
-        return super(CalrissianExecutor, self).run_jobs(process, job_order_object, logger, runtime_context)

--- a/calrissian/executor.py
+++ b/calrissian/executor.py
@@ -19,6 +19,10 @@ class CalrissianExecutor(MultithreadedJobExecutor):
         self.max_cores = max_cores
         log.debug('Initialized executor to allow {} MB RAM and {} CPU cores'.format(self.max_ram, self.max_cores))
 
+    def select_resources(self, request, runtime_context):
+        log.debug('CalrissianExecutor.select_resources: {}'.format(request))
+        return super(CalrissianExecutor, self).select_resources(request, runtime_context)
+
     def run_jobs(self,
                  process,           # type: Process
                  job_order_object,  # type: Dict[Text, Any]

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -117,7 +117,7 @@ class KubernetesVolumeBuilder(object):
 
 class KubernetesPodBuilder(object):
 
-    def __init__(self, name, container_image, environment, volume_mounts, volumes, command_line, stdout, stderr, stdin):
+    def __init__(self, name, container_image, environment, volume_mounts, volumes, command_line, stdout, stderr, stdin, resources):
         self.name = name
         self.container_image = container_image
         self.environment = environment
@@ -127,6 +127,7 @@ class KubernetesPodBuilder(object):
         self.stdout = stdout
         self.stderr = stderr
         self.stdin = stdin
+        self.resources = resources
 
     def pod_name(self):
         return k8s_safe_name('{}-pod'.format(self.name))
@@ -170,6 +171,47 @@ class KubernetesPodBuilder(object):
         """
         return self.environment['HOME']
 
+    # Conversions from CWL ResourceRequirements https://www.commonwl.org/v1.0/CommandLineTool.html#ResourceRequirement
+    # to Kubernetes Resource requests/limits
+    # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container
+
+    @staticmethod
+    def resource_bound(cwl_field):
+        if cwl_field.endswith('Min'):
+            return 'requests'
+        elif cwl_field.endswith('Max'):
+            return 'limits'
+        else:
+            return None
+
+    @staticmethod
+    def resource_type(cwl_field):
+        if cwl_field.startswith('cores'):
+            return 'cpu'
+        elif cwl_field.startswith('ram'):
+            return 'memory'
+        else:
+            return None
+
+    @staticmethod
+    def resource_value(kind, cwl_value):
+        if kind == 'cpu':
+            return '{}'.format(cwl_value)
+        elif kind == 'memory':
+            return '{}Mi'.format(cwl_value)
+
+    def container_resources(self):
+        container_resources = {}
+        for cwl_field, cwl_value in self.resources.items():
+            resource_bound = self.resource_bound(cwl_field)
+            resource_type = self.resource_type(cwl_field)
+            resource_value = self.resource_value(resource_type, cwl_value)
+            if resource_bound and resource_type and resource_value:
+                if not container_resources.get(resource_bound):
+                    container_resources[resource_bound] = {}
+                container_resources[resource_bound][resource_type] = resource_value
+        return container_resources
+
     def build(self):
         return {
             'metadata': {
@@ -185,6 +227,7 @@ class KubernetesPodBuilder(object):
                             'command': self.container_command(),
                             'args': self.container_args(),
                             'env': self.container_environment(),
+                            'resources': self.container_resources(),
                             'volumeMounts': self.volume_mounts,
                             'workingDir': self.container_workingdir(),
                          }
@@ -283,7 +326,8 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
             self.command_line,
             self.stdout,
             self.stderr,
-            self.stdin
+            self.stdin,
+            self.builder.resources,
         )
         built = k8s_builder.build()
         log.debug('{}\n{}{}\n'.format('-' * 80, yaml.dump(built), '-' * 80))

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -3,6 +3,7 @@ from calrissian.context import CalrissianLoadingContext
 from calrissian.version import version
 from cwltool.main import main as cwlmain
 from cwltool.argparser import arg_parser
+import argparse
 import logging
 import sys
 
@@ -13,11 +14,24 @@ def activate_logging():
         logging.getLogger('calrissian.{}'.format(logger)).addHandler(logging.StreamHandler())
 
 
+def add_arguments(parser):
+    parser.add_argument('--max-ram', type=int, help='Maximum amount of RAM in MB to use')
+    parser.add_argument('--max-cores', type=int, help='Maximum number of CPU cores to use')
+
+
+def check_arguments(parser, args):
+    if not (args.max_ram and args.max_cores):
+        parser.print_help()
+        sys.exit(1)
+
+
 def main():
     parser = arg_parser()
+    add_arguments(parser)
     parsed_args = parser.parse_args()
+    check_arguments(parser, parsed_args)
     result = cwlmain(args=parsed_args,
-                     executor=CalrissianExecutor(),
+                     executor=CalrissianExecutor(parsed_args.max_ram, parsed_args.max_cores),
                      loadingContext=CalrissianLoadingContext(),
                      versionfunc=version,
                      )

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -19,17 +19,18 @@ def add_arguments(parser):
     parser.add_argument('--max-cores', type=int, help='Maximum number of CPU cores to use')
 
 
-def check_arguments(parser, args):
+def parse_arguments(parser):
+    args = parser.parse_args()
     if not (args.max_ram and args.max_cores):
         parser.print_help()
         sys.exit(1)
+    return args
 
 
 def main():
     parser = arg_parser()
     add_arguments(parser)
-    parsed_args = parser.parse_args()
-    check_arguments(parser, parsed_args)
+    parsed_args = parse_arguments(parser)
     result = cwlmain(args=parsed_args,
                      executor=CalrissianExecutor(parsed_args.max_ram, parsed_args.max_cores),
                      loadingContext=CalrissianLoadingContext(),

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -3,7 +3,7 @@ from calrissian.context import CalrissianLoadingContext
 from calrissian.version import version
 from cwltool.main import main as cwlmain
 from cwltool.argparser import arg_parser
-import argparse
+from cwltool.context import RuntimeContext
 import logging
 import sys
 
@@ -31,9 +31,13 @@ def main():
     parser = arg_parser()
     add_arguments(parser)
     parsed_args = parse_arguments(parser)
+    executor = CalrissianExecutor(parsed_args.max_ram, parsed_args.max_cores)
+    runtimeContext = RuntimeContext(vars(parsed_args))
+    runtimeContext.select_resources = executor.select_resources
     result = cwlmain(args=parsed_args,
-                     executor=CalrissianExecutor(parsed_args.max_ram, parsed_args.max_cores),
+                     executor=executor,
                      loadingContext=CalrissianLoadingContext(),
+                     runtimeContext=runtimeContext,
                      versionfunc=version,
                      )
     return result

--- a/input-data/revsort-array.cwl
+++ b/input-data/revsort-array.cwl
@@ -25,6 +25,10 @@ steps:
     out: [output]
     scatter: input
     run: revtool.cwl
+    requirements:
+      - class: ResourceRequirement
+        coresMin: 1
+        ramMin: 100
   sorted:
     in:
       input: rev/output
@@ -32,3 +36,7 @@ steps:
     scatter: input
     out: [output]
     run: sorttool.cwl
+    requirements:
+      - class: ResourceRequirement
+        coresMin: 1
+        ramMin: 100

--- a/openshift/CalrissianJob-fail-wf.yaml
+++ b/openshift/CalrissianJob-fail-wf.yaml
@@ -10,7 +10,7 @@ spec:
         # Jobs cannot use ImageStream images directly, so we have to provide the registry/repo variant
         image: docker-registry.default.svc:5000/calrissian/calrissian:latest
         command: ["/bin/bash", "-c"]
-        args: ["python -m calrissian.main --tmpdir-prefix /calrissian/tmptmp/ --tmp-outdir-prefix /calrissian/tmpout/ --outdir /calrissian/output-data/ /calrissian/input-data/fail-wf.cwl /calrissian/input-data/fail-wf-job.json"]
+        args: ["python -m calrissian.main --max-ram 1024 --max-cores 2 --tmpdir-prefix /calrissian/tmptmp/ --tmp-outdir-prefix /calrissian/tmpout/ --outdir /calrissian/output-data/ /calrissian/input-data/fail-wf.cwl /calrissian/input-data/fail-wf-job.json"]
         volumeMounts:
         - mountPath: /calrissian/input-data
           name: calrissian-input-data

--- a/openshift/CalrissianJob-revsort.yaml
+++ b/openshift/CalrissianJob-revsort.yaml
@@ -11,7 +11,7 @@ spec:
         # Jobs cannot use ImageStream images directly, so we have to provide the registry/repo variant
         image: docker-registry.default.svc:5000/calrissian/calrissian:latest
         command: ["/bin/bash", "-c"]
-        args: ["python -m calrissian.main --tmpdir-prefix /calrissian/tmptmp/ --tmp-outdir-prefix /calrissian/tmpout/ --outdir /calrissian/output-data/ /calrissian/input-data/revsort-array.cwl /calrissian/input-data/revsort-array-job.json"]
+        args: ["python -m calrissian.main --max-ram 16384 --max-cores 8 --tmpdir-prefix /calrissian/tmptmp/ --tmp-outdir-prefix /calrissian/tmpout/ --outdir /calrissian/output-data/ /calrissian/input-data/revsort-array.cwl /calrissian/input-data/revsort-array-job.json"]
         volumeMounts:
         - mountPath: /calrissian/input-data
           name: calrissian-input-data

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -5,5 +5,19 @@ from calrissian.executor import CalrissianExecutor
 class CalrissianExecutorTestCase(TestCase):
 
     def test_init(self):
-        e = CalrissianExecutor()
+        e = CalrissianExecutor(0, 0)
         self.assertIsNotNone(e)
+
+    def test_max_ram(self):
+        e = CalrissianExecutor(100, 0)
+        self.assertEqual(e.max_ram, 100)
+        # Test that base class init is still called
+        self.assertEqual(e.allocated_ram, 0)
+        self.assertEqual(e.allocated_cores, 0)
+
+    def test_max_cores(self):
+        e = CalrissianExecutor(0, 4)
+        self.assertEqual(e.max_cores, 4)
+        # Test that base class init is still called
+        self.assertEqual(e.allocated_ram, 0)
+        self.assertEqual(e.allocated_cores, 0)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,20 +9,25 @@ class CalrissianMainTestCase(TestCase):
     @patch('calrissian.main.arg_parser')
     @patch('calrissian.main.CalrissianExecutor')
     @patch('calrissian.main.CalrissianLoadingContext')
+    @patch('calrissian.main.RuntimeContext')
     @patch('calrissian.main.version')
     @patch('calrissian.main.parse_arguments')
     @patch('calrissian.main.add_arguments')
-    def test_main_calls_cwlmain_returns_exit_code(self, mock_add_arguments, mock_parse_arguments, mock_version, mock_loading_context, mock_executor, mock_arg_parser, mock_cwlmain):
+    def test_main_calls_cwlmain_returns_exit_code(self, mock_add_arguments, mock_parse_arguments, mock_version, mock_runtime_context, mock_loading_context, mock_executor, mock_arg_parser, mock_cwlmain):
         mock_exit_code = Mock()
         mock_cwlmain.return_value = mock_exit_code
         result = main()
         self.assertTrue(mock_arg_parser.called)
         self.assertEqual(mock_add_arguments.call_args, call(mock_arg_parser.return_value))
         self.assertEqual(mock_parse_arguments.call_args, call(mock_arg_parser.return_value))
+        self.assertEqual(mock_executor.call_args, call(mock_parse_arguments.return_value.max_ram, mock_parse_arguments.return_value.max_cores))
+        self.assertTrue(mock_runtime_context.called)
         self.assertEqual(mock_cwlmain.call_args, call(args=mock_parse_arguments.return_value,
                                                       executor=mock_executor.return_value,
                                                       loadingContext=mock_loading_context.return_value,
+                                                      runtimeContext=mock_runtime_context.return_value,
                                                       versionfunc=mock_version))
+        self.assertEqual(mock_runtime_context.return_value.select_resources, mock_executor.return_value.select_resources)
         self.assertEqual(result, mock_exit_code)
 
     def test_add_arguments(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from unittest.mock import patch, call, Mock
-from calrissian.main import main
+from calrissian.main import main, add_arguments, parse_arguments
 
 
 class CalrissianMainTestCase(TestCase):
@@ -10,13 +10,44 @@ class CalrissianMainTestCase(TestCase):
     @patch('calrissian.main.CalrissianExecutor')
     @patch('calrissian.main.CalrissianLoadingContext')
     @patch('calrissian.main.version')
-    def test_main_calls_cwlmain_returns_exit_code(self, mock_version, mock_loading_context, mock_executor, mock_arg_parser, mock_cwlmain):
+    @patch('calrissian.main.parse_arguments')
+    @patch('calrissian.main.add_arguments')
+    def test_main_calls_cwlmain_returns_exit_code(self, mock_add_arguments, mock_parse_arguments, mock_version, mock_loading_context, mock_executor, mock_arg_parser, mock_cwlmain):
         mock_exit_code = Mock()
         mock_cwlmain.return_value = mock_exit_code
         result = main()
         self.assertTrue(mock_arg_parser.called)
-        self.assertEqual(mock_cwlmain.call_args, call(args=mock_arg_parser.return_value.parse_args.return_value,
+        self.assertEqual(mock_add_arguments.call_args, call(mock_arg_parser.return_value))
+        self.assertEqual(mock_parse_arguments.call_args, call(mock_arg_parser.return_value))
+        self.assertEqual(mock_cwlmain.call_args, call(args=mock_parse_arguments.return_value,
                                                       executor=mock_executor.return_value,
                                                       loadingContext=mock_loading_context.return_value,
                                                       versionfunc=mock_version))
         self.assertEqual(result, mock_exit_code)
+
+    def test_add_arguments(self):
+        mock_parser = Mock()
+        add_arguments(mock_parser)
+        self.assertEqual(mock_parser.add_argument.call_count, 2)
+
+    @patch('calrissian.main.sys')
+    def test_parse_arguments_exits_without_ram_or_cores(self, mock_sys):
+        mock_parser = Mock()
+        mock_parser.parse_args.return_value = Mock(max_ram=None, max_cores=None)
+        parse_arguments(mock_parser)
+        self.assertEqual(mock_sys.exit.call_args, call(1))
+
+    @patch('calrissian.main.sys')
+    def test_parse_arguments_exits_with_ram_but_no_cores(self, mock_sys):
+        mock_parser = Mock()
+        mock_parser.parse_args.return_value = Mock(max_ram=2048, max_cores=None)
+        parse_arguments(mock_parser)
+        self.assertEqual(mock_sys.exit.call_args, call(1))
+
+    @patch('calrissian.main.sys')
+    def test_parse_arguments_succeeds_with_ram_and_cores(self, mock_sys):
+        mock_parser = Mock()
+        mock_parser.parse_args.return_value = Mock(max_ram=2048, max_cores=3)
+        parsed = parse_arguments(mock_parser)
+        self.assertEqual(parsed, mock_parser.parse_args.return_value)
+        self.assertFalse(mock_sys.exit.called)


### PR DESCRIPTION
- Adds required parameters `--max-ram` and `--max-cores` to calrissian.main. Running on the command-line now requires specifying these limits for parallelization
- Updates example jobs to include these values
- Converts CWL resource requirements to kubernetes container resource requests/limits
- Annotates rev/sort steps in sample workflow to request 1 core and 100 MB ram

I tested this on local minishift with the default 4GB RAM and 2 CPUs. Found that the workflow did parallelize about 3 jobs.