### PR TITLE
Update ImageStream to let jobs use local image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ CWL on Kubernetes
 
 Calrissian is a [CWL](https://www.commonwl.org) implementation designed to run individual steps as Pods in a kubernetes cluster
 
-It is in development and includes a simple workflow (revsort [single](input-data/revsort-single.cwl) / [array](input-data/revsort-array.cwl) to reverse and sort the contents of text files.
+It is in development and includes a simple workflow (revsort [single](input-data/revsort-single.cwl) / [array](input-data/revsort-array.cwl)) to reverse and sort the contents of text files.
 
 ## Preparing Openshift
 
@@ -52,5 +52,4 @@ With the VolumeClaims and Build processes in place, you can run the example with
 
 ## Notes
 
-1. Jobs cannot use ImageStreams, they must use standard docker registry URLs. Since these URLs include the namespace/project, you'll likely need to tweak the urls in the Job YAML if your project is not named `calrissian`.
-2. Calrissian will delete completed jobs for individual steps, but you may want to delete the `calrissian-revsort-array` job manually after running it.
+1. Calrissian will delete completed jobs for individual steps, but you may want to delete the `calrissian-revsort-array` job manually after running it.

--- a/openshift/BuildConfig.yaml
+++ b/openshift/BuildConfig.yaml
@@ -11,7 +11,7 @@ items:
     name: calrissian
   spec:
     lookupPolicy:
-      local: false
+      local: true
   status:
     dockerImageRepository: ""
 - apiVersion: v1

--- a/openshift/CalrissianJob-fail-wf.yaml
+++ b/openshift/CalrissianJob-fail-wf.yaml
@@ -7,8 +7,7 @@ spec:
     spec:
       containers:
       - name: calrissian
-        # Jobs cannot use ImageStream images directly, so we have to provide the registry/repo variant
-        image: docker-registry.default.svc:5000/calrissian/calrissian:latest
+        image: calrissian:latest
         command: ["/bin/bash", "-c"]
         args: ["python -m calrissian.main --max-ram 1024 --max-cores 2 --tmpdir-prefix /calrissian/tmptmp/ --tmp-outdir-prefix /calrissian/tmpout/ --outdir /calrissian/output-data/ /calrissian/input-data/fail-wf.cwl /calrissian/input-data/fail-wf-job.json"]
         volumeMounts:

--- a/openshift/CalrissianJob-revsort.yaml
+++ b/openshift/CalrissianJob-revsort.yaml
@@ -8,8 +8,7 @@ spec:
     spec:
       containers:
       - name: calrissian
-        # Jobs cannot use ImageStream images directly, so we have to provide the registry/repo variant
-        image: docker-registry.default.svc:5000/calrissian/calrissian:latest
+        image: calrissian:latest
         command: ["/bin/bash", "-c"]
         args: ["python -m calrissian.main --max-ram 16384 --max-cores 8 --tmpdir-prefix /calrissian/tmptmp/ --tmp-outdir-prefix /calrissian/tmpout/ --outdir /calrissian/output-data/ /calrissian/input-data/revsort-array.cwl /calrissian/input-data/revsort-array-job.json"]
         volumeMounts:

--- a/openshift/StageInputDataJob.yaml
+++ b/openshift/StageInputDataJob.yaml
@@ -7,8 +7,7 @@ spec:
     spec:
       containers:
       - name: stage-input-data
-        # Jobs cannot use ImageStream images directly, so we have to provide the registry/repo variant
-        image: docker-registry.default.svc:5000/calrissian/calrissian:latest
+        image: calrissian:latest
         command:
         - "sh"
         - "-c"


### PR DESCRIPTION
As documented in https://docs.openshift.com/container-platform/3.11/dev_guide/managing_images.html#using-is-with-k8s, the image lookup policy can be set to allow Kubernetes resources (like Jobs) to lookup image stream images.

This change enables that in BuildConfig.yaml and uses it in the jobs.