### PR TITLE
Injects DockerRequirement into tool if it is not present

### DIFF
--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -17,6 +17,10 @@ class VolumeBuilderException(Exception):
     pass
 
 
+class CalrissianCommandLineJobException(Exception):
+    pass
+
+
 def k8s_safe_name(name):
     """
     Kubernetes does not allow underscores
@@ -290,10 +294,15 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
         self.output_callback(outputs, status)
 
     def _get_container_image(self):
-        # we only use dockerPull here
-        # Could possibly make an API call to kubernetes to check for the image there, but that's not important right now
-        (docker_req, docker_is_req) = self.get_requirement("DockerRequirement")
-        return str(docker_req["dockerPull"])
+        docker_requirement, _ = self.get_requirement('DockerRequirement')
+        if docker_requirement:
+            container_image = docker_requirement['dockerPull']
+        else:
+            # No dockerRequirement, use the default container
+            container_image = self.builder.find_default_container()
+        if not container_image:
+            raise CalrissianCommandLineJobException('Unable to create Job - Please ensure tool has a DockerRequirement with dockerPull or specify a default_container')
+        return container_image
 
     def create_kubernetes_runtime(self, runtimeContext):
         # In cwltool, the runtime list starts as something like ['docker','run'] and these various builder methods

--- a/calrissian/tool.py
+++ b/calrissian/tool.py
@@ -5,8 +5,10 @@ import logging
 
 log = logging.getLogger("calrissian.tool")
 
+
 class CalrissianToolException(BaseException):
     pass
+
 
 class CalrissianCommandLineTool(CommandLineTool):
 
@@ -17,7 +19,6 @@ class CalrissianCommandLineTool(CommandLineTool):
         :return: a callable that runs the job
         """
         # This implementation runs CommandLineTools exclusively in containers
-        # so we need to add a DockerRequirement if it's not present
         if not runtimeContext.use_container:
             raise CalrissianToolException('Unable to create a CalrissianCommandLineTool - use_container is disabled')
         return CalrissianCommandLineJob

--- a/calrissian/tool.py
+++ b/calrissian/tool.py
@@ -20,17 +20,6 @@ class CalrissianCommandLineTool(CommandLineTool):
         # so we need to add a DockerRequirement if it's not present
         if not runtimeContext.use_container:
             raise CalrissianToolException('Unable to create a CalrissianCommandLineTool - use_container is disabled')
-        docker_requirement, _ = self.get_requirement('DockerRequirement')
-        if not docker_requirement:
-            # no docker requirement specified, inject one
-            default_container = runtimeContext.find_default_container(self)
-            if not default_container:
-                raise CalrissianToolException('Unable to create a CalrissianCommandLineTool - '
-                                              'tool has no DockerRequirement and no default_container specified')
-            self.requirements.insert(0, {
-                'class': 'DockerRequirement',
-                'dockerPull': default_container
-            })
         return CalrissianCommandLineJob
 
 

--- a/calrissian/tool.py
+++ b/calrissian/tool.py
@@ -19,8 +19,20 @@ class CalrissianCommandLineTool(CommandLineTool):
         :return: a callable that runs the job
         """
         # This implementation runs CommandLineTools exclusively in containers
+        # so we need to add a DockerRequirement if it's not present
         if not runtimeContext.use_container:
             raise CalrissianToolException('Unable to create a CalrissianCommandLineTool - use_container is disabled')
+        docker_requirement, _ = self.get_requirement('DockerRequirement')
+        if not docker_requirement:
+            # no docker requirement specified, inject one
+            default_container = runtimeContext.find_default_container(self)
+            if not default_container:
+                raise CalrissianToolException('Unable to create a CalrissianCommandLineTool - '
+                                              'tool has no DockerRequirement and no default_container specified')
+            self.requirements.insert(0, {
+                'class': 'DockerRequirement',
+                'dockerPull': default_container
+            })
         return CalrissianCommandLineJob
 
 

--- a/calrissian/tool.py
+++ b/calrissian/tool.py
@@ -18,8 +18,21 @@ class CalrissianCommandLineTool(CommandLineTool):
         :param runtimeContext: RuntimeContext object
         :return: a callable that runs the job
         """
-        # This implementation runs CommandLineTools exclusively in containers
-        # so we need to add a DockerRequirement if it's not present
+        # Calrissian runs CommandLineTools exclusively in containers, so must always return a CalrissianCommandLineJob
+        # If the tool definition does NOT have a DockerRequirement, we inject one here before returning the job_runner.
+        #
+        # Notes on why this is done here (as opposed to inside the job):
+        #
+        # 1. The job() method in the base CommandLineTool class (which this class inherits) checks for DockerRequirement
+        #    before setting the job's outdir, tmpdir, and stagedir. When the requirement is not present, local dirs
+        #    are used, which don't get mounted correctly to the container:
+        # See https://github.com/common-workflow-language/cwltool/blob/a94d75178c24ce77b59403fb8276af9ad1998929/cwltool/command_line_tool.py#L506-L515
+        #
+        # 2. The make_job_runner() method in the base CommandLineTool injects a DockerRequirement when appropriate.
+        #    Since we're overriding that method, we must inject the same requirement to be consistent with behavior in
+        #    (1) above.
+        # See https://github.com/common-workflow-language/cwltool/blob/a94d75178c24ce77b59403fb8276af9ad1998929/cwltool/command_line_tool.py#L243
+
         if not runtimeContext.use_container:
             raise CalrissianToolException('Unable to create a CalrissianCommandLineTool - use_container is disabled')
         docker_requirement, _ = self.get_requirement('DockerRequirement')

--- a/calrissian/tool.py
+++ b/calrissian/tool.py
@@ -6,7 +6,7 @@ import logging
 log = logging.getLogger("calrissian.tool")
 
 
-class CalrissianToolException(BaseException):
+class CalrissianCommandLineToolException(BaseException):
     pass
 
 
@@ -34,13 +34,13 @@ class CalrissianCommandLineTool(CommandLineTool):
         # See https://github.com/common-workflow-language/cwltool/blob/a94d75178c24ce77b59403fb8276af9ad1998929/cwltool/command_line_tool.py#L243
 
         if not runtimeContext.use_container:
-            raise CalrissianToolException('Unable to create a CalrissianCommandLineTool - use_container is disabled')
+            raise CalrissianCommandLineToolException('Unable to create a CalrissianCommandLineTool - use_container is disabled')
         docker_requirement, _ = self.get_requirement('DockerRequirement')
         if not docker_requirement:
             # no docker requirement specified, inject one
             default_container = runtimeContext.find_default_container(self)
             if not default_container:
-                raise CalrissianToolException('Unable to create a CalrissianCommandLineTool - '
+                raise CalrissianCommandLineToolException('Unable to create a CalrissianCommandLineTool - '
                                               'tool has no DockerRequirement and no default_container specified')
             self.requirements.insert(0, {
                 'class': 'DockerRequirement',

--- a/calrissian/tool.py
+++ b/calrissian/tool.py
@@ -5,10 +5,32 @@ import logging
 
 log = logging.getLogger("calrissian.tool")
 
+class CalrissianToolException(BaseException):
+    pass
+
 class CalrissianCommandLineTool(CommandLineTool):
 
     def make_job_runner(self, runtimeContext):
-        # This should return a callable
+        """
+        Construct a callable that can run a CommandLineTool
+        :param runtimeContext: RuntimeContext object
+        :return: a callable that runs the job
+        """
+        # This implementation runs CommandLineTools exclusively in containers
+        # so we need to add a DockerRequirement if it's not present
+        if not runtimeContext.use_container:
+            raise CalrissianToolException('Unable to create a CalrissianCommandLineTool - use_container is disabled')
+        docker_requirement, _ = self.get_requirement('DockerRequirement')
+        if not docker_requirement:
+            # no docker requirement specified, inject one
+            default_container = runtimeContext.find_default_container(self)
+            if not default_container:
+                raise CalrissianToolException('Unable to create a CalrissianCommandLineTool - '
+                                              'tool has no DockerRequirement and no default_container specified')
+            self.requirements.insert(0, {
+                'class': 'DockerRequirement',
+                'dockerPull': default_container
+            })
         return CalrissianCommandLineJob
 
 

--- a/input-data/revsort-array.cwl
+++ b/input-data/revsort-array.cwl
@@ -8,16 +8,16 @@ requirements:
 inputs:
   input:
     type: File[]
-    doc: "The input file to be processed."
+    doc: "Array of input files to be processed."
   reverse_sort:
     type: boolean
     default: true
-    doc: "If true, reverse (decending) sort"
+    doc: "If true, reverse (descending) sort"
 outputs:
   output:
     type: File[]
     outputSource: sorted/output
-    doc: "The output with the lines reversed and sorted."
+    doc: "The output files with the lines reversed and sorted."
 steps:
   rev:
     in:

--- a/input-data/revsort-single-no-docker.cwl
+++ b/input-data/revsort-single-no-docker.cwl
@@ -9,7 +9,7 @@ inputs:
   reverse_sort:
     type: boolean
     default: true
-    doc: "If true, reverse (decending) sort"
+    doc: "If true, reverse (descending) sort"
 outputs:
   output:
     type: File

--- a/input-data/revsort-single-no-docker.cwl
+++ b/input-data/revsort-single-no-docker.cwl
@@ -1,0 +1,30 @@
+class: Workflow
+doc: "Reverse the lines in a document, then sort those lines."
+cwlVersion: v1.0
+
+inputs:
+  input:
+    type: File
+    doc: "The input file to be processed."
+  reverse_sort:
+    type: boolean
+    default: true
+    doc: "If true, reverse (decending) sort"
+outputs:
+  output:
+    type: File
+    outputSource: sorted/output
+    doc: "The output with the lines reversed and sorted."
+steps:
+  rev:
+    in:
+      input: input
+    out: [output]
+    run: revtool-no-docker.cwl
+
+  sorted:
+    in:
+      input: rev/output
+      reverse: reverse_sort
+    out: [output]
+    run: sorttool-no-docker.cwl

--- a/input-data/revtool-no-docker.cwl
+++ b/input-data/revtool-no-docker.cwl
@@ -1,0 +1,16 @@
+class: CommandLineTool
+cwlVersion: v1.0
+doc: "Reverse each line using the `rev` command"
+requirements:
+  - class: InlineJavascriptRequirement
+inputs:
+  input:
+    type: File
+    inputBinding: {}
+outputs:
+  output:
+    type: File
+    outputBinding:
+      glob: $('reversed-' + inputs.input.basename)
+baseCommand: rev
+stdout: $('reversed-' + inputs.input.basename)

--- a/input-data/sorttool-no-docker.cwl
+++ b/input-data/sorttool-no-docker.cwl
@@ -1,0 +1,24 @@
+class: CommandLineTool
+doc: "Sort lines using the `sort` command"
+cwlVersion: v1.0
+requirements:
+  - class: InlineJavascriptRequirement
+inputs:
+  - id: reverse
+    type: boolean
+    inputBinding:
+      position: 1
+      prefix: "--reverse"
+  - id: input
+    type: File
+    inputBinding:
+      position: 2
+
+outputs:
+  - id: output
+    type: File
+    outputBinding:
+      glob: $('sorted-' + inputs.input.basename)
+
+baseCommand: sort
+stdout: $('sorted-' + inputs.input.basename)

--- a/openshift/CalrissianJob-revsort-single-default-container.yaml
+++ b/openshift/CalrissianJob-revsort-single-default-container.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: calrissian-revsort-single-default-container
+spec:
+  template:
+    spec:
+      containers:
+      - name: calrissian
+        image: calrissian:latest
+        command: ["/bin/bash", "-c"]
+        args: ["python -m calrissian.main --default-container debian:stretch-slim --max-ram 16384 --max-cores 8 --tmpdir-prefix /calrissian/tmptmp/ --tmp-outdir-prefix /calrissian/tmpout/ --outdir /calrissian/output-data/ /calrissian/input-data/revsort-single-no-docker.cwl /calrissian/input-data/revsort-single-job.json"]
+        volumeMounts:
+        - mountPath: /calrissian/input-data
+          name: calrissian-input-data
+        - mountPath: /calrissian/tmpout
+          name: calrissian-tmpout
+        - mountPath: /calrissian/tmptmp
+          name: calrissian-tmp
+        - mountPath: /calrissian/output-data
+          name: calrissian-output-data
+        env:
+        - name: CALRISSIAN_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+      restartPolicy: Never
+      volumes:
+      - name: calrissian-input-data
+        persistentVolumeClaim:
+          claimName: calrissian-input-data
+      - name: calrissian-tmpout
+        persistentVolumeClaim:
+          claimName: calrissian-tmpout
+      - name: calrissian-tmp
+        persistentVolumeClaim:
+          claimName: calrissian-tmp
+      - name: calrissian-output-data
+        persistentVolumeClaim:
+          claimName: calrissian-output-data
+  backOffLimit: 0

--- a/openshift/CalrissianJob-revsort-single.yaml
+++ b/openshift/CalrissianJob-revsort-single.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: calrissian-revsort-single
+spec:
+  template:
+    spec:
+      containers:
+      - name: calrissian
+        image: calrissian:latest
+        command: ["/bin/bash", "-c"]
+        args: ["python -m calrissian.main --max-ram 16384 --max-cores 8 --tmpdir-prefix /calrissian/tmptmp/ --tmp-outdir-prefix /calrissian/tmpout/ --outdir /calrissian/output-data/ /calrissian/input-data/revsort-single.cwl /calrissian/input-data/revsort-single-job.json"]
+        volumeMounts:
+        - mountPath: /calrissian/input-data
+          name: calrissian-input-data
+        - mountPath: /calrissian/tmpout
+          name: calrissian-tmpout
+        - mountPath: /calrissian/tmptmp
+          name: calrissian-tmp
+        - mountPath: /calrissian/output-data
+          name: calrissian-output-data
+        env:
+        - name: CALRISSIAN_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+      restartPolicy: Never
+      volumes:
+      - name: calrissian-input-data
+        persistentVolumeClaim:
+          claimName: calrissian-input-data
+      - name: calrissian-tmpout
+        persistentVolumeClaim:
+          claimName: calrissian-tmpout
+      - name: calrissian-tmp
+        persistentVolumeClaim:
+          claimName: calrissian-tmp
+      - name: calrissian-output-data
+        persistentVolumeClaim:
+          claimName: calrissian-output-data
+  backOffLimit: 0

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -25,27 +25,25 @@ class CalrissianMakeToolTestCase(TestCase):
 
 class CalrissianCommandLineToolTestCase(TestCase):
 
+    def setUp(self):
+        self.toolpath_object = {'id': '1', 'inputs': [], 'outputs': []}
+        self.loadingContext = CalrissianLoadingContext()
+
     @patch('calrissian.tool.CalrissianCommandLineJob')
     def test_make_job_runner(self, mock_command_line_job):
-        toolpath_object = {'id': '1', 'inputs': [], 'outputs': []}
-        loadingContext = CalrissianLoadingContext()
-        tool = CalrissianCommandLineTool(toolpath_object, loadingContext)
+        tool = CalrissianCommandLineTool(self.toolpath_object, self.loadingContext)
         runner = tool.make_job_runner(Mock())
         self.assertEqual(runner, mock_command_line_job)
 
     def test_fails_use_container_false(self):
-        toolpath_object = {'id': '1', 'inputs': [], 'outputs': []}
-        loadingContext = CalrissianLoadingContext()
-        tool = CalrissianCommandLineTool(toolpath_object, loadingContext)
+        tool = CalrissianCommandLineTool(self.toolpath_object, self.loadingContext)
         runtimeContext = Mock(use_container=False)
         with self.assertRaises(CalrissianToolException) as context:
             tool.make_job_runner(runtimeContext)
         self.assertIn('use_container is disabled', str(context.exception))
 
     def test_fails_no_default_container(self):
-        toolpath_object = {'id': '1', 'inputs': [], 'outputs': []}
-        loadingContext = CalrissianLoadingContext()
-        tool = CalrissianCommandLineTool(toolpath_object, loadingContext)
+        tool = CalrissianCommandLineTool(self.toolpath_object, self.loadingContext)
         runtimeContext = Mock()
         runtimeContext.find_default_container.return_value = None
         with self.assertRaises(CalrissianToolException) as context:

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -41,3 +41,28 @@ class CalrissianCommandLineToolTestCase(TestCase):
         with self.assertRaises(CalrissianToolException) as context:
             tool.make_job_runner(runtimeContext)
         self.assertIn('use_container is disabled', str(context.exception))
+
+    def test_fails_no_default_container(self):
+        tool = CalrissianCommandLineTool(self.toolpath_object, self.loadingContext)
+        runtimeContext = Mock()
+        runtimeContext.find_default_container.return_value = None
+        with self.assertRaises(CalrissianToolException) as context:
+            tool.make_job_runner(runtimeContext)
+        self.assertIn('no default_container', str(context.exception))
+
+    def test_injects_default_container(self):
+        tool = CalrissianCommandLineTool(self.toolpath_object, self.loadingContext)
+        runtimeContext = Mock(use_container=True)
+        runtimeContext.find_default_container.return_value = 'docker:default-container'
+        self.assertEqual([], tool.requirements)
+        tool.make_job_runner(runtimeContext)
+        self.assertIn({'class': 'DockerRequirement', 'dockerPull': 'docker:default-container'}, tool.requirements)
+
+    def test_uses_docker_requirement_container(self):
+        self.toolpath_object['requirements'] = [{'class': 'DockerRequirement', 'dockerPull': 'docker:tool-container'}]
+        tool = CalrissianCommandLineTool(self.toolpath_object, self.loadingContext)
+        runtimeContext = Mock(use_container=True)
+        runtimeContext.find_default_container.return_value = 'docker:default-container'
+        tool.make_job_runner(runtimeContext)
+        self.assertNotIn({'class': 'DockerRequirement', 'dockerPull': 'docker:default-container'}, tool.requirements)
+        self.assertIn({'class': 'DockerRequirement', 'dockerPull': 'docker:tool-container'}, tool.requirements)

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch, call
-from calrissian.tool import CalrissianCommandLineTool, calrissian_make_tool, CalrissianToolException
+from calrissian.tool import CalrissianCommandLineTool, calrissian_make_tool, CalrissianCommandLineToolException
 from calrissian.context import CalrissianLoadingContext
 
 
@@ -38,7 +38,7 @@ class CalrissianCommandLineToolTestCase(TestCase):
     def test_fails_use_container_false(self):
         tool = CalrissianCommandLineTool(self.toolpath_object, self.loadingContext)
         runtimeContext = Mock(use_container=False)
-        with self.assertRaises(CalrissianToolException) as context:
+        with self.assertRaises(CalrissianCommandLineToolException) as context:
             tool.make_job_runner(runtimeContext)
         self.assertIn('use_container is disabled', str(context.exception))
 
@@ -46,7 +46,7 @@ class CalrissianCommandLineToolTestCase(TestCase):
         tool = CalrissianCommandLineTool(self.toolpath_object, self.loadingContext)
         runtimeContext = Mock()
         runtimeContext.find_default_container.return_value = None
-        with self.assertRaises(CalrissianToolException) as context:
+        with self.assertRaises(CalrissianCommandLineToolException) as context:
             tool.make_job_runner(runtimeContext)
         self.assertIn('no default_container', str(context.exception))
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -51,4 +51,18 @@ class CalrissianCommandLineToolTestCase(TestCase):
         self.assertIn('no default_container', str(context.exception))
 
     def test_injects_default_container(self):
-        self.fail()
+        tool = CalrissianCommandLineTool(self.toolpath_object, self.loadingContext)
+        runtimeContext = Mock(use_container=True)
+        runtimeContext.find_default_container.return_value = 'docker:default-container'
+        self.assertEqual([], tool.requirements)
+        tool.make_job_runner(runtimeContext)
+        self.assertIn({'class': 'DockerRequirement', 'dockerPull': 'docker:default-container'}, tool.requirements)
+
+    def test_uses_docker_requirement_container(self):
+        self.toolpath_object['requirements'] = [{'class': 'DockerRequirement', 'dockerPull': 'docker:tool-container'}]
+        tool = CalrissianCommandLineTool(self.toolpath_object, self.loadingContext)
+        runtimeContext = Mock(use_container=True)
+        runtimeContext.find_default_container.return_value = 'docker:default-container'
+        tool.make_job_runner(runtimeContext)
+        self.assertNotIn({'class': 'DockerRequirement', 'dockerPull': 'docker:default-container'}, tool.requirements)
+        self.assertIn({'class': 'DockerRequirement', 'dockerPull': 'docker:tool-container'}, tool.requirements)

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -41,28 +41,3 @@ class CalrissianCommandLineToolTestCase(TestCase):
         with self.assertRaises(CalrissianToolException) as context:
             tool.make_job_runner(runtimeContext)
         self.assertIn('use_container is disabled', str(context.exception))
-
-    def test_fails_no_default_container(self):
-        tool = CalrissianCommandLineTool(self.toolpath_object, self.loadingContext)
-        runtimeContext = Mock()
-        runtimeContext.find_default_container.return_value = None
-        with self.assertRaises(CalrissianToolException) as context:
-            tool.make_job_runner(runtimeContext)
-        self.assertIn('no default_container', str(context.exception))
-
-    def test_injects_default_container(self):
-        tool = CalrissianCommandLineTool(self.toolpath_object, self.loadingContext)
-        runtimeContext = Mock(use_container=True)
-        runtimeContext.find_default_container.return_value = 'docker:default-container'
-        self.assertEqual([], tool.requirements)
-        tool.make_job_runner(runtimeContext)
-        self.assertIn({'class': 'DockerRequirement', 'dockerPull': 'docker:default-container'}, tool.requirements)
-
-    def test_uses_docker_requirement_container(self):
-        self.toolpath_object['requirements'] = [{'class': 'DockerRequirement', 'dockerPull': 'docker:tool-container'}]
-        tool = CalrissianCommandLineTool(self.toolpath_object, self.loadingContext)
-        runtimeContext = Mock(use_container=True)
-        runtimeContext.find_default_container.return_value = 'docker:default-container'
-        tool.make_job_runner(runtimeContext)
-        self.assertNotIn({'class': 'DockerRequirement', 'dockerPull': 'docker:default-container'}, tool.requirements)
-        self.assertIn({'class': 'DockerRequirement', 'dockerPull': 'docker:tool-container'}, tool.requirements)

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch, call
-from calrissian.tool import CalrissianCommandLineTool, calrissian_make_tool
+from calrissian.tool import CalrissianCommandLineTool, calrissian_make_tool, CalrissianToolException
 from calrissian.context import CalrissianLoadingContext
 
 
@@ -32,3 +32,25 @@ class CalrissianCommandLineToolTestCase(TestCase):
         tool = CalrissianCommandLineTool(toolpath_object, loadingContext)
         runner = tool.make_job_runner(Mock())
         self.assertEqual(runner, mock_command_line_job)
+
+    def test_fails_use_container_false(self):
+        toolpath_object = {'id': '1', 'inputs': [], 'outputs': []}
+        loadingContext = CalrissianLoadingContext()
+        tool = CalrissianCommandLineTool(toolpath_object, loadingContext)
+        runtimeContext = Mock(use_container=False)
+        with self.assertRaises(CalrissianToolException) as context:
+            tool.make_job_runner(runtimeContext)
+        self.assertIn('use_container is disabled', str(context.exception))
+
+    def test_fails_no_default_container(self):
+        toolpath_object = {'id': '1', 'inputs': [], 'outputs': []}
+        loadingContext = CalrissianLoadingContext()
+        tool = CalrissianCommandLineTool(toolpath_object, loadingContext)
+        runtimeContext = Mock()
+        runtimeContext.find_default_container.return_value = None
+        with self.assertRaises(CalrissianToolException) as context:
+            tool.make_job_runner(runtimeContext)
+        self.assertIn('no default_container', str(context.exception))
+
+    def test_injects_default_container(self):
+        self.fail()


### PR DESCRIPTION
- CalrissianCommandLineTool now injects a DockerRequirement with the `--default-container` docker image if the tool has no DockerRequirement. This mirrors behavior in cwltool's base CommandLineTool and is explained in comments.
- CalrissianCommandLineJob now checks for unsupported `DockerRequirement` features and fails if they cannot be met
-  Adds version of revsort single file workflow that does not include a `DockerRequirement` for testing these features. See sample job `CalrissianJob-revsort-single-default-container.yaml` that calls it and specifies `--default-container`

Fixes #7 