### PR TITLE
Changes based on bringing a real workflow online

### DIFF
--- a/calrissian/executor.py
+++ b/calrissian/executor.py
@@ -19,3 +19,22 @@ class CalrissianExecutor(MultithreadedJobExecutor):
         self.max_cores = max_cores
         log.debug('Initialized executor to allow {} MB RAM and {} CPU cores'.format(self.max_ram, self.max_cores))
 
+    def run_job(self, *args, **kwargs):
+        self.report_usage('run_job')
+        return super(CalrissianExecutor, self).run_job(*args, **kwargs)
+
+    def wait_for_next_completion(self, *args, **kwargs):
+        self.report_usage('wait_for_next_completion')
+        return super(CalrissianExecutor, self).wait_for_next_completion(*args, **kwargs)
+
+    def run_jobs(self, *args, **kwargs):
+        self.report_usage('run_jobs')
+        return super(CalrissianExecutor, self).run_jobs(*args, **kwargs)
+
+    def execute(self, *args, **kwargs):
+        self.report_usage('execute')
+        return super(CalrissianExecutor, self).execute(*args, **kwargs)
+
+    def report_usage(self, caller=''):
+        log.debug('{}: Allocated {}/{} CPU cores, {}/{} MB RAM'.format(caller, self.allocated_cores, self.max_cores,
+                                                                   self.allocated_ram, self.max_ram))

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -35,6 +35,10 @@ def k8s_safe_name(name):
     return name.lower().replace('_', '-')
 
 
+def random_tag(length=8):
+    return ''.join(random.choices(string.ascii_lowercase, k=length))
+
+
 class KubernetesPodVolumeInspector(object):
     def __init__(self, pod):
         self.pod = pod
@@ -108,10 +112,6 @@ class KubernetesVolumeBuilder(object):
         else:
             return source_without_prefix
 
-    @staticmethod
-    def random_tag(length=8):
-        return ''.join(random.choices(string.ascii_lowercase, k=length))
-
     def add_volume_binding(self, source, target, writable):
         # Find the persistent volume claim where this goes
         pv = self.find_persistent_volume(source)
@@ -142,7 +142,7 @@ class KubernetesPodBuilder(object):
         self.resources = resources
 
     def pod_name(self):
-        tag = KubernetesVolumeBuilder.random_tag()
+        tag = random_tag()
         return k8s_safe_name('{}-pod-{}'.format(self.name, tag))
 
     def container_name(self):

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -168,6 +168,20 @@ class KubernetesClientTestCase(TestCase):
             mock_get_namespace.return_value, field_selector='metadata.name=mypod'
         )
 
+    @patch('calrissian.k8s.os')
+    def test_should_delete_pod_defaults_yes(self, mock_os, mock_get_namespace, mock_client):
+        mock_os.getenv.return_value = ''
+        kc = KubernetesClient()
+        self.assertTrue(kc.should_delete_pod())
+        self.assertEqual(mock_os.getenv.call_args, call('CALRISSIAN_DELETE_PODS', ''))
+
+    @patch('calrissian.k8s.os')
+    def test_should_delete_pod_reads_env(self, mock_os, mock_get_namespace, mock_client):
+        mock_os.getenv.return_value = 'NO'
+        kc = KubernetesClient()
+        self.assertFalse(kc.should_delete_pod())
+        self.assertEqual(mock_os.getenv.call_args, call('CALRISSIAN_DELETE_PODS', ''))
+
 
 class KubernetesClientStateTestCase(TestCase):
 


### PR DESCRIPTION
Updates from attempting to run [exomeseq-gatk4-preprocessing.cwl](https://github.com/Duke-GCB/bespin-cwl/blob/master/workflows/exomeseq-gatk4-preprocessing.cwl)

- Makes pod names unique
- Adds option to skip deleting pods
- Adjusts some logging, reports usage before executor methods
- Quotes arguments in container args array if needed
- Fixes translation of CWL ResourceRequirements to k8s resources
