### PR TITLE
Setuptools installer, Dockerfile, and updated BuildConfig

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.6
 LABEL maintainer="dan.leehr@duke.edu"
 
+# cwltool requires nodejs
+RUN apt-get update && apt-get install -y nodejs
+
 RUN mkdir -p /app
 COPY . /app
 RUN pip install /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.6
+LABEL maintainer="dan.leehr@duke.edu"
+
+RUN mkdir -p /app
+COPY . /app
+RUN pip install /app
+
+CMD ["calrissian"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ RUN apt-get update && apt-get install -y nodejs
 RUN mkdir -p /app
 COPY . /app
 RUN pip install /app
+WORKDIR /app
 
 CMD ["calrissian"]

--- a/calrissian/version.py
+++ b/calrissian/version.py
@@ -2,10 +2,10 @@ import pkg_resources  # part of setuptools
 
 
 def package_version(package_name):
-    pkg = pkg_resources.require(package_name)
-    if pkg:
+    try:
+        pkg = pkg_resources.require(package_name)
         return pkg[0].version
-    else:
+    except pkg_resources.DistributionNotFound:
         return 'unknown'
 
 

--- a/calrissian/version.py
+++ b/calrissian/version.py
@@ -1,3 +1,21 @@
+import pkg_resources  # part of setuptools
+
+
+def package_version(package_name):
+    pkg = pkg_resources.require(package_name)
+    if pkg:
+        return pkg[0].version
+    else:
+        return 'unknown'
+
+
+def cwltool_version():
+    return package_version('cwltool')
+
+
+def calrissian_version():
+    return package_version('calrissian')
+
 
 def version():
-    return 'Calrissian-dev'
+    return 'calrissian {} (cwltool {})'.format(calrissian_version(), cwltool_version())

--- a/openshift/BuildConfig.yaml
+++ b/openshift/BuildConfig.yaml
@@ -33,7 +33,7 @@ items:
     resources: {}
     source:
       git:
-        ref: 40-packaging
+        ref: master
         uri: https://github.com/Duke-GCB/calrissian.git
       type: Git
     strategy:

--- a/openshift/BuildConfig.yaml
+++ b/openshift/BuildConfig.yaml
@@ -1,13 +1,28 @@
 apiVersion: v1
 items:
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    name: python
+    namespace: calrissian
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+      - from:
+          kind: DockerImage
+          name: 'python:3.6'
+        name: '3.6'
+        referencePolicy:
+          type: Source
 - apiVersion: v1
   kind: ImageStream
   metadata:
     annotations:
-      openshift.io/generated-by: OpenShiftNewApp
+      openshift.io/generated-by: OpenShiftNewBuild
     creationTimestamp: null
     labels:
-      app: calrissian
+      build: calrissian
     name: calrissian
   spec:
     lookupPolicy:
@@ -18,10 +33,10 @@ items:
   kind: BuildConfig
   metadata:
     annotations:
-      openshift.io/generated-by: OpenShiftNewApp
+      openshift.io/generated-by: OpenShiftNewBuild
     creationTimestamp: null
     labels:
-      app: calrissian
+      build: calrissian
     name: calrissian
   spec:
     nodeSelector: null
@@ -33,16 +48,16 @@ items:
     resources: {}
     source:
       git:
-        ref: master
-        uri: https://github.com/Duke-GCB/calrissian
+        ref: 599d5aa322abdd6cd4cd5246f2fc590e652f5736
+        uri: https://github.com/Duke-GCB/calrissian.git
       type: Git
     strategy:
-      sourceStrategy:
+      dockerStrategy:
         from:
           kind: ImageStreamTag
           name: python:3.6
-          namespace: openshift
-      type: Source
+          namespace: calrissian
+      type: Docker
     triggers:
     - type: ConfigChange
     - imageChange: {}

--- a/openshift/BuildConfig.yaml
+++ b/openshift/BuildConfig.yaml
@@ -33,7 +33,7 @@ items:
     resources: {}
     source:
       git:
-        ref: 40-packaging-python-official-base
+        ref: 40-packaging
         uri: https://github.com/Duke-GCB/calrissian.git
       type: Git
     strategy:

--- a/openshift/BuildConfig.yaml
+++ b/openshift/BuildConfig.yaml
@@ -1,20 +1,5 @@
 apiVersion: v1
 items:
-- apiVersion: image.openshift.io/v1
-  kind: ImageStream
-  metadata:
-    name: python
-    namespace: calrissian
-  spec:
-    lookupPolicy:
-      local: false
-    tags:
-      - from:
-          kind: DockerImage
-          name: 'python:3.6'
-        name: '3.6'
-        referencePolicy:
-          type: Source
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -48,15 +33,10 @@ items:
     resources: {}
     source:
       git:
-        ref: 599d5aa322abdd6cd4cd5246f2fc590e652f5736
+        ref: 40-packaging-python-official-base
         uri: https://github.com/Duke-GCB/calrissian.git
       type: Git
     strategy:
-      dockerStrategy:
-        from:
-          kind: ImageStreamTag
-          name: python:3.6
-          namespace: calrissian
       type: Docker
     triggers:
     - type: ConfigChange

--- a/openshift/CalrissianJob-fail-wf.yaml
+++ b/openshift/CalrissianJob-fail-wf.yaml
@@ -8,8 +8,20 @@ spec:
       containers:
       - name: calrissian
         image: calrissian:latest
-        command: ["/bin/bash", "-c"]
-        args: ["python -m calrissian.main --max-ram 1024 --max-cores 2 --tmpdir-prefix /calrissian/tmptmp/ --tmp-outdir-prefix /calrissian/tmpout/ --outdir /calrissian/output-data/ /calrissian/input-data/fail-wf.cwl /calrissian/input-data/fail-wf-job.json"]
+        command: ["calrissian"]
+        args:
+          - "--max-ram"
+          - "1024"
+          - "--max-cores"
+          - "2"
+          - "--tmpdir-prefix"
+          - "/calrissian/tmptmp/"
+          - "--tmp-outdir-prefix"
+          - "/calrissian/tmpout/"
+          - "--outdir"
+          - "/calrissian/output-data/"
+          - "/calrissian/input-data/fail-wf.cwl"
+          - "/calrissian/input-data/fail-wf-job.json"
         volumeMounts:
         - mountPath: /calrissian/input-data
           name: calrissian-input-data

--- a/openshift/CalrissianJob-revsort-single-default-container.yaml
+++ b/openshift/CalrissianJob-revsort-single-default-container.yaml
@@ -9,8 +9,22 @@ spec:
       containers:
       - name: calrissian
         image: calrissian:latest
-        command: ["/bin/bash", "-c"]
-        args: ["python -m calrissian.main --default-container debian:stretch-slim --max-ram 16384 --max-cores 8 --tmpdir-prefix /calrissian/tmptmp/ --tmp-outdir-prefix /calrissian/tmpout/ --outdir /calrissian/output-data/ /calrissian/input-data/revsort-single-no-docker.cwl /calrissian/input-data/revsort-single-job.json"]
+        command: ["calrissian"]
+        args:
+          - "--default-container"
+          - "debian:stretch-slim"
+          - "--max-ram"
+          - "16384"
+          - "--max-cores"
+          - "8"
+          - "--tmpdir-prefix"
+          - "/calrissian/tmptmp/"
+          - "--tmp-outdir-prefix"
+          - "/calrissian/tmpout/"
+          - "--outdir"
+          - "/calrissian/output-data/"
+          - "/calrissian/input-data/revsort-single-no-docker.cwl"
+          - "/calrissian/input-data/revsort-single-job.json"
         volumeMounts:
         - mountPath: /calrissian/input-data
           name: calrissian-input-data

--- a/openshift/CalrissianJob-revsort-single.yaml
+++ b/openshift/CalrissianJob-revsort-single.yaml
@@ -9,8 +9,20 @@ spec:
       containers:
       - name: calrissian
         image: calrissian:latest
-        command: ["/bin/bash", "-c"]
-        args: ["python -m calrissian.main --max-ram 16384 --max-cores 8 --tmpdir-prefix /calrissian/tmptmp/ --tmp-outdir-prefix /calrissian/tmpout/ --outdir /calrissian/output-data/ /calrissian/input-data/revsort-single.cwl /calrissian/input-data/revsort-single-job.json"]
+        command: ["calrissian"]
+        args:
+          - "--max-ram"
+          - "16384"
+          - "--max-cores"
+          - "8"
+          - "--tmpdir-prefix"
+          - "/calrissian/tmptmp/"
+          - "--tmp-outdir-prefix"
+          - "/calrissian/tmpout/"
+          - "--outdir"
+          - "/calrissian/output-data/"
+          - "/calrissian/input-data/revsort-single.cwl"
+          - "/calrissian/input-data/revsort-single-job.json"
         volumeMounts:
         - mountPath: /calrissian/input-data
           name: calrissian-input-data

--- a/openshift/CalrissianJob-revsort.yaml
+++ b/openshift/CalrissianJob-revsort.yaml
@@ -9,8 +9,20 @@ spec:
       containers:
       - name: calrissian
         image: calrissian:latest
-        command: ["/bin/bash", "-c"]
-        args: ["python -m calrissian.main --max-ram 16384 --max-cores 8 --tmpdir-prefix /calrissian/tmptmp/ --tmp-outdir-prefix /calrissian/tmpout/ --outdir /calrissian/output-data/ /calrissian/input-data/revsort-array.cwl /calrissian/input-data/revsort-array-job.json"]
+        command: ["calrissian"]
+        args:
+          - "--max-ram"
+          - "16384"
+          - "--max-cores"
+          - "8"
+          - "--tmpdir-prefix"
+          - "/calrissian/tmptmp/"
+          - "--tmp-outdir-prefix"
+          - "/calrissian/tmpout/"
+          - "--outdir"
+          - "/calrissian/output-data/"
+          - "/calrissian/input-data/revsort-array.cwl"
+          - "/calrissian/input-data/revsort-array-job.json"
         volumeMounts:
         - mountPath: /calrissian/input-data
           name: calrissian-input-data

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ decorator==4.3.0
 google-auth==1.6.2
 idna==2.8
 isodate==0.6.0
-kubernetes==8.0.0
+kubernetes==8.0.1
 lockfile==0.12.2
 lxml==4.2.5
 mistune==0.8.4

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -13,7 +13,7 @@ setup(
         'cwltool==1.0.20181217162649',
         'kubernetes==8.0.1',
     ],
-    test_suite='nose2',
+    test_suite='nose2.collector.collector',
     tests_require=['nose2'],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,37 @@
+from distutils.core import setup
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup(
+    name='calrissian',
+    version='0.1.0',
+    author='Dan Leehr',
+    author_email='dan.leehr@duke.edu',
+    description='CWL runner for Kubernetes',
+    install_requires=[
+        'cwltool==1.0.20181217162649',
+        'kubernetes==8.0.1',
+    ],
+    test_suite='nose2',
+    tests_require=['nose2'],
+    entry_points={
+        'console_scripts': [
+            'calrissian = calrissian.main:main'
+        ]
+    },
+    license='MIT',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    url='https://github.com/Duke-GCB/calrissian',
+    packages=['calrissian',],
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Programming Language :: Python :: 3',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Topic :: Scientific/Engineering :: Bio-Informatics',
+        'Topic :: System :: Distributed Computing',
+    ],
+)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,9 +1,27 @@
 from unittest import TestCase
-from calrissian.version import version
+from unittest.mock import Mock, patch
+
+from calrissian.version import version, package_version
 
 
 class VersionTestCase(TestCase):
 
-    def test_version(self):
-        self.assertEqual(version(), 'Calrissian-dev')
+    @patch('calrissian.version.cwltool_version')
+    @patch('calrissian.version.calrissian_version')
+    def test_assembles_vession_string(self, mock_calrissian_version, mock_cwltool_version):
+        mock_cwltool_version.return_value = '3.2.1'
+        mock_calrissian_version.return_value = '1.2.3'
+        self.assertEqual(version(), 'calrissian 1.2.3 (cwltool 3.2.1)')
 
+    @patch('calrissian.version.pkg_resources')
+    def test_package_version_unknown(self, mock_pkg_resources):
+        mock_pkg_resources.DistributionNotFound = Exception
+        mock_pkg_resources.require.side_effect = mock_pkg_resources.DistributionNotFound()
+        self.assertEqual(package_version('package-name'), 'unknown')
+        self.assertTrue(mock_pkg_resources.require.called)
+
+    @patch('calrissian.version.pkg_resources')
+    def test_package_version_known(self, mock_pkg_resources):
+        mock_pkg_resources.require.return_value = [Mock(version='1.2.3'), ]
+        self.assertEqual(package_version('package-name'), '1.2.3')
+        self.assertTrue(mock_pkg_resources.require.called)


### PR DESCRIPTION
- Adds setup.py with packaging information (as initial version 0.1.0). When installed, can be run as `calrissian` instead of `python -m ...`
- Updates `version.py` to report the version of calrissian and cwltool
- Adds Dockerfile to install on top of `python:3.6` (includes nodejs)
- Rewrites openshift BuildConfig to use the `Dockerfile` instead of a source-to-image build.
- Updates example job to use the `calrissian` CLI script as `command` and arguments as `args`.

Fixes #40 