### PR TITLE
Print out version and exit when running `calrissian --version`

### DIFF
--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -7,6 +7,7 @@ from cwltool.context import RuntimeContext
 import logging
 import sys
 
+
 def activate_logging():
     loggers = ['executor','context','tool','job', 'k8s']
     for logger in loggers:
@@ -19,8 +20,16 @@ def add_arguments(parser):
     parser.add_argument('--max-cores', type=int, help='Maximum number of CPU cores to use')
 
 
+def print_version():
+    print(version())
+
+
 def parse_arguments(parser):
     args = parser.parse_args()
+    # Check for version arg
+    if args.version:
+        print_version()
+        sys.exit(0)
     if not (args.max_ram and args.max_cores):
         parser.print_help()
         sys.exit(1)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -56,3 +56,13 @@ class CalrissianMainTestCase(TestCase):
         parsed = parse_arguments(mock_parser)
         self.assertEqual(parsed, mock_parser.parse_args.return_value)
         self.assertFalse(mock_sys.exit.called)
+
+    @patch('calrissian.main.sys')
+    @patch('calrissian.main.version')
+    def test_parse_arguments_exits_with_version(self, mock_version, mock_sys):
+        mock_parser = Mock()
+        mock_parser.parse_args.return_value = Mock(version=True)
+        parsed = parse_arguments(mock_parser)
+        self.assertEqual(parsed, mock_parser.parse_args.return_value)
+        self.assertTrue(mock_version.called)
+        self.assertEqual(mock_sys.exit.call_args, call(0))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,31 +38,31 @@ class CalrissianMainTestCase(TestCase):
     @patch('calrissian.main.sys')
     def test_parse_arguments_exits_without_ram_or_cores(self, mock_sys):
         mock_parser = Mock()
-        mock_parser.parse_args.return_value = Mock(max_ram=None, max_cores=None)
+        mock_parser.parse_args.return_value = Mock(max_ram=None, max_cores=None, version=None)
         parse_arguments(mock_parser)
         self.assertEqual(mock_sys.exit.call_args, call(1))
 
     @patch('calrissian.main.sys')
     def test_parse_arguments_exits_with_ram_but_no_cores(self, mock_sys):
         mock_parser = Mock()
-        mock_parser.parse_args.return_value = Mock(max_ram=2048, max_cores=None)
+        mock_parser.parse_args.return_value = Mock(max_ram=2048, max_cores=None, version=None)
         parse_arguments(mock_parser)
         self.assertEqual(mock_sys.exit.call_args, call(1))
 
     @patch('calrissian.main.sys')
     def test_parse_arguments_succeeds_with_ram_and_cores(self, mock_sys):
         mock_parser = Mock()
-        mock_parser.parse_args.return_value = Mock(max_ram=2048, max_cores=3)
+        mock_parser.parse_args.return_value = Mock(max_ram=2048, max_cores=3, version=None)
         parsed = parse_arguments(mock_parser)
         self.assertEqual(parsed, mock_parser.parse_args.return_value)
         self.assertFalse(mock_sys.exit.called)
 
     @patch('calrissian.main.sys')
-    @patch('calrissian.main.version')
-    def test_parse_arguments_exits_with_version(self, mock_version, mock_sys):
+    @patch('calrissian.main.print_version')
+    def test_parse_arguments_exits_with_version(self, mock_print_version, mock_sys):
         mock_parser = Mock()
         mock_parser.parse_args.return_value = Mock(version=True)
         parsed = parse_arguments(mock_parser)
         self.assertEqual(parsed, mock_parser.parse_args.return_value)
-        self.assertTrue(mock_version.called)
+        self.assertTrue(mock_print_version.called)
         self.assertEqual(mock_sys.exit.call_args, call(0))


### PR DESCRIPTION
Allows user to run `calrissian --version` without requiring `--max-ram` and `--max-cores`

Fixes #43 