### PR TITLE
Option to apply labels to submitted pods

### DIFF
--- a/calrissian/context.py
+++ b/calrissian/context.py
@@ -1,5 +1,5 @@
 from calrissian.tool import calrissian_make_tool
-from cwltool.context import LoadingContext
+from cwltool.context import LoadingContext, RuntimeContext
 import logging
 
 log = logging.getLogger('calrissian.context')
@@ -9,3 +9,13 @@ class CalrissianLoadingContext(LoadingContext):
     def __init__(self, **kwargs):
         kwargs['construct_tool_object'] = calrissian_make_tool
         return super(CalrissianLoadingContext, self).__init__(kwargs)
+
+
+class CalrissianRuntimeContext(RuntimeContext):
+
+    def __init__(self, kwargs=None):
+        # The ContextBase class sets values from kwargs if the class has that attribute
+        # So, if we want to capture an init param of pod_labels, we just set it to
+        # None and let super() handle the rest.
+        self.pod_labels = None
+        return super(CalrissianRuntimeContext, self).__init__(kwargs)

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -227,11 +227,18 @@ class KubernetesPodBuilder(object):
                 container_resources[resource_bound][resource_type] = resource_value
         return container_resources
 
+    def pod_labels(self):
+        """
+        Submitted labels must be strings
+        :return:
+        """
+        return {str(k): str(v) for k, v in self.labels.items()}
+
     def build(self):
         return {
             'metadata': {
                 'name': self.pod_name(),
-                'labels': self.labels,
+                'labels': self.pod_labels(),
             },
             'apiVersion': 'v1',
             'kind':'Pod',

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -1,10 +1,10 @@
 from calrissian.executor import CalrissianExecutor
-from calrissian.context import CalrissianLoadingContext
+from calrissian.context import CalrissianLoadingContext, CalrissianRuntimeContext
 from calrissian.version import version
 from calrissian.k8s import delete_pods
 from cwltool.main import main as cwlmain
 from cwltool.argparser import arg_parser
-from cwltool.context import RuntimeContext
+from typing_extensions import Text
 import logging
 import sys
 import signal
@@ -20,6 +20,7 @@ def activate_logging():
 def add_arguments(parser):
     parser.add_argument('--max-ram', type=int, help='Maximum amount of RAM in MB to use')
     parser.add_argument('--max-cores', type=int, help='Maximum number of CPU cores to use')
+    parser.add_argument('--pod-labels', type=Text, nargs='?', help='YAML file of labels to add to Pods submitted')
 
 
 def print_version():
@@ -59,14 +60,14 @@ def main():
     add_arguments(parser)
     parsed_args = parse_arguments(parser)
     executor = CalrissianExecutor(parsed_args.max_ram, parsed_args.max_cores)
-    runtimeContext = RuntimeContext(vars(parsed_args))
-    runtimeContext.select_resources = executor.select_resources
+    runtime_context = CalrissianRuntimeContext(vars(parsed_args))
+    runtime_context.select_resources = executor.select_resources
     install_signal_handler()
     try:
         result = cwlmain(args=parsed_args,
                          executor=executor,
                          loadingContext=CalrissianLoadingContext(),
-                         runtimeContext=runtimeContext,
+                         runtimeContext=runtime_context,
                          versionfunc=version,
                          )
     finally:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from unittest.mock import patch
-from calrissian.context import CalrissianLoadingContext
+from calrissian.context import CalrissianLoadingContext, CalrissianRuntimeContext
 
 
 class CalrissianLoadingContextTestCase(TestCase):
@@ -9,3 +9,15 @@ class CalrissianLoadingContextTestCase(TestCase):
     def test_uses_calrissian_make_tool(self, mock_make_tool):
         ctx = CalrissianLoadingContext()
         self.assertEqual(ctx.construct_tool_object, mock_make_tool)
+
+
+class CalrissianRuntimeContextTestCase(TestCase):
+
+    def test_has_pod_labels_field(self):
+        ctx = CalrissianRuntimeContext()
+        self.assertIsNone(ctx.pod_labels)
+
+    def test_sets_pod_labels_field(self):
+        labels = {'key1': 'val1'}
+        ctx = CalrissianRuntimeContext({'pod_labels':labels})
+        self.assertEqual(ctx.pod_labels, labels)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -192,7 +192,7 @@ class KubernetesPodBuilderTestCase(TestCase):
         self.stderr = 'stderr.txt'
         self.stdin = 'stdin.txt'
         self.resources = {'cores': 1, 'ram': 1024}
-        self.labels = {'key1': 'val1'}
+        self.labels = {'key1': 'val1', 'key2': 123}
         self.pod_builder = KubernetesPodBuilder(self.name, self.container_image, self.environment, self.volume_mounts,
                                                 self.volumes, self.command_line, self.stdout, self.stderr, self.stdin,
                                                 self.resources, self.labels)
@@ -250,6 +250,10 @@ class KubernetesPodBuilderTestCase(TestCase):
         }
         self.assertEqual(expected, resources)
 
+    def test_string_labels(self):
+        self.pod_builder.labels = {'key1': 123}
+        self.assertEqual(self.pod_builder.pod_labels(), {'key1':'123'})
+
     @patch('calrissian.job.random_tag')
     def test_build(self, mock_random_tag):
         mock_random_tag.return_value = 'random'
@@ -258,6 +262,7 @@ class KubernetesPodBuilderTestCase(TestCase):
                 'name': 'podname-pod-random',
                 'labels': {
                     'key1': 'val1',
+                    'key2': '123',
                 }
             },
             'apiVersion': 'v1',

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch, call
-from calrissian.job import k8s_safe_name, KubernetesVolumeBuilder, VolumeBuilderException, KubernetesPodBuilder, random_tag
+from calrissian.job import k8s_safe_name, KubernetesVolumeBuilder, VolumeBuilderException, KubernetesPodBuilder, random_tag, read_yaml
 from calrissian.job import CalrissianCommandLineJob, KubernetesPodVolumeInspector, CalrissianCommandLineJobException
 from cwltool.errors import UnsupportedRequirement
 
@@ -21,6 +21,7 @@ class RandomTagTestCase(TestCase):
         self.assertEqual(len(tag1), 10)
         self.assertEqual(len(tag2), 10)
         self.assertNotEqual(tag1, tag2)
+
 
 class KubernetesPodVolumeInspectorTestCase(TestCase):
     def test_first_container_with_one_container(self):
@@ -191,9 +192,10 @@ class KubernetesPodBuilderTestCase(TestCase):
         self.stderr = 'stderr.txt'
         self.stdin = 'stdin.txt'
         self.resources = {'cores': 1, 'ram': 1024}
+        self.labels = {'key1': 'val1'}
         self.pod_builder = KubernetesPodBuilder(self.name, self.container_image, self.environment, self.volume_mounts,
                                                 self.volumes, self.command_line, self.stdout, self.stderr, self.stdin,
-                                                self.resources)
+                                                self.resources, self.labels)
 
     @patch('calrissian.job.random_tag')
     def test_safe_pod_name(self, mock_random_tag):
@@ -253,7 +255,10 @@ class KubernetesPodBuilderTestCase(TestCase):
         mock_random_tag.return_value = 'random'
         expected = {
             'metadata': {
-                'name': 'podname-pod-random'
+                'name': 'podname-pod-random',
+                'labels': {
+                    'key1': 'val1',
+                }
             },
             'apiVersion': 'v1',
             'kind':'Pod',
@@ -403,7 +408,8 @@ class CalrissianCommandLineJobTestCase(TestCase):
 
     @patch('calrissian.job.KubernetesPodBuilder')
     @patch('calrissian.job.os')
-    def test_create_kubernetes_runtime(self, mock_os, mock_pod_builder, mock_volume_builder, mock_client):
+    @patch('calrissian.job.read_yaml')
+    def test_create_kubernetes_runtime(self, mock_read_yaml, mock_os, mock_pod_builder, mock_volume_builder, mock_client):
         def realpath(path):
             return '/real' + path
         mock_os.path.realpath = realpath
@@ -433,7 +439,8 @@ class CalrissianCommandLineJobTestCase(TestCase):
             job.stdout,
             job.stderr,
             job.stdin,
-            job.builder.resources
+            job.builder.resources,
+            mock_read_yaml.return_value,
         ))
         # calls builder.build
         # returns that
@@ -537,3 +544,19 @@ class CalrissianCommandLineJobTestCase(TestCase):
         self.assertEqual(job.execute_kubernetes_pod.call_args, call(job.create_kubernetes_runtime.return_value))
         self.assertTrue(job.wait_for_kubernetes_pod.called)
         self.assertEqual(job.finish.call_args, call(job.wait_for_kubernetes_pod.return_value))
+
+    @patch('calrissian.job.read_yaml')
+    def test_get_pod_labels(self, mock_read_yaml, mock_volume_builder, mock_client):
+        expected_labels = {'foo':'bar'}
+        mock_read_yaml.return_value = expected_labels
+        mock_runtime_context = Mock(pod_labels='labels.yaml')
+        job = self.make_job()
+        labels = job.get_pod_labels(mock_runtime_context)
+        self.assertEqual(labels, expected_labels)
+        self.assertEqual(mock_read_yaml.call_args, call('labels.yaml'))
+
+    def test_get_pod_labels_empty(self, mock_volume_builder, mock_client):
+        mock_runtime_context = Mock(pod_labels=None)
+        job = self.make_job()
+        labels = job.get_pod_labels(mock_runtime_context)
+        self.assertEqual(labels, {})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import patch, call, Mock
 
 from calrissian.main import main, add_arguments, parse_arguments, handle_sigterm, install_signal_handler
+from cwltool.argparser import arg_parser
 
 
 class CalrissianMainTestCase(TestCase):
@@ -10,7 +11,7 @@ class CalrissianMainTestCase(TestCase):
     @patch('calrissian.main.arg_parser')
     @patch('calrissian.main.CalrissianExecutor')
     @patch('calrissian.main.CalrissianLoadingContext')
-    @patch('calrissian.main.RuntimeContext')
+    @patch('calrissian.main.CalrissianRuntimeContext')
     @patch('calrissian.main.version')
     @patch('calrissian.main.parse_arguments')
     @patch('calrissian.main.add_arguments')
@@ -42,7 +43,7 @@ class CalrissianMainTestCase(TestCase):
     def test_add_arguments(self):
         mock_parser = Mock()
         add_arguments(mock_parser)
-        self.assertEqual(mock_parser.add_argument.call_count, 2)
+        self.assertEqual(mock_parser.add_argument.call_count, 3)
 
     @patch('calrissian.main.sys')
     def test_parse_arguments_exits_without_ram_or_cores(self, mock_sys):


### PR DESCRIPTION
Add labels to submitted Pods using --pod-labels <yaml_file>

- Adds CalrissianRuntimeContext subclass with a pod_labels attribute
- CalrissianCommandLineJob reads the YAML (or JSON) file of labels and provides a dictionary to KubernetesPodBuilder
- KubernetesPodBuilder takes a dictionary of labels in its constructor, to provide as the pod's metadata.labels (ensuring conversion to string)

Fixes #38