### PR TITLE
Remove namespace from VolumeClaims

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is in development and includes a simple workflow (revsort [single](input-data
 
 The `openshift/` directory contains YAML files that demonstrate the basic functionality. To configure Openshift, do the following:
 
-1. Create a project in openshift (e.g. `calrissian-demo`). Note that namespaces must be unique, so if `calrissian-demo-project` is already in use on the cluster, you will need to choose a different name.
+1. Create a project in openshift (e.g. `calrissian-demo-project`). Note that namespaces must be unique, so if `calrissian-demo-project` is already in use on the cluster, you will need to choose a different name.
 
         oc new-project calrissian-demo-project
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ It is in development and includes a simple workflow (revsort [single](input-data
 
 The `openshift/` directory contains YAML files that demonstrate the basic functionality. To configure Openshift, do the following:
 
-1. Create a project in openshift (e.g. `calrissian`). Note that namespaces must be unique, so if `calrissian` is already in use on the cluster, you will need to choose a different name here and other places where the namespace is referenced.
+1. Create a project in openshift (e.g. `calrissian-demo`). Note that namespaces must be unique, so if `calrissian-demo-project` is already in use on the cluster, you will need to choose a different name.
 
-        oc new-project calrissian
+        oc new-project calrissian-demo-project
 
 2. Create a role in your project to allow managing `Pod`s:
 
@@ -24,7 +24,7 @@ The `openshift/` directory contains YAML files that demonstrate the basic functi
 
 3. Bind your project's default service account access to these roles. Calrissian running inside the cluster will use this service account to make Kubernetes API calls.
 
-        oc create rolebinding pod-manager-default-binding --role=pod-manager-role --serviceaccount=calrissian:default
+        oc create rolebinding pod-manager-default-binding --role=pod-manager-role --serviceaccount=calrissian-demo-project:default
 
 4. Create the BuildConfig - this allows Openshift to build the source code into a Docker image and starts a build automatically. If you wish to build a different branch or repo, edit this file.
 

--- a/openshift/VolumeClaims.yaml
+++ b/openshift/VolumeClaims.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: calrissian-input-data
-  namespace: calrissian
 spec:
   accessModes:
     - ReadWriteMany
@@ -14,7 +13,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: calrissian-tmpout
-  namespace: calrissian
 spec:
   accessModes:
     - ReadWriteMany
@@ -26,7 +24,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: calrissian-tmp
-  namespace: calrissian
 spec:
   accessModes:
     - ReadWriteMany
@@ -38,7 +35,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: calrissian-output-data
-  namespace: calrissian
 spec:
   accessModes:
     - ReadWriteMany


### PR DESCRIPTION
Example volume claims in `openshift/VolumeClaims.yaml` had a namespace specified. This is not necessary, and by removing it, the examples can more easily be run on other namespaces, and we don't need to adjust the examples in `openshift/` for templating with scripts or helm.

Closes #18 