### PR TITLE
Set HOME and create default user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ WORKDIR /app
 
 # Create a default user and home directory
 ENV HOME=/home/calrissian
+# home dir is created by useradd with group (g=0) to comply with
+# https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
 RUN useradd -u 1001 -r -g 0 -m -d ${HOME} -s /sbin/nologin \
       -c "Default Calrissian User" calrissian && \
   chown -R 1001:0 /app && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,12 @@ COPY . /app
 RUN pip install /app
 WORKDIR /app
 
+# Create a default user and home directory
+ENV HOME=/home/calrissian
+RUN useradd -u 1001 -r -g 0 -m -d ${HOME} -s /sbin/nologin \
+      -c "Default Calrissian User" calrissian && \
+  chown -R 1001:0 /app && \
+  chmod g+rwx ${HOME}
+
+USER calrissian
 CMD ["calrissian"]


### PR DESCRIPTION
Creates `$HOME` at `/home/calrissian`, owned and writable by group `0`.

This follows the openshift practices for [Supporting Arbitrary User IDs](https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines)