### PR TITLE
Adds --stdout and --stderr args for writing output to files

### DIFF
--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -71,12 +71,12 @@ def install_tees(stdout_path=None, stderr_path=None):
     """
 
     if stdout_path:
-        sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+        sys.stdout = os.fdopen(sys.stdout.fileno(), 'wb', 0)
         stdout_tee_process = subprocess.Popen(["tee", stdout_path], stdin=subprocess.PIPE)
         os.dup2(stdout_tee_process.stdin.fileno(), sys.stdout.fileno())
 
     if stderr_path:
-        sys.stderr = os.fdopen(sys.stderr.fileno(), 'w', 0)
+        sys.stderr = os.fdopen(sys.stderr.fileno(), 'wb', 0)
         stderr_tee_process = subprocess.Popen(["tee", stderr_path], stdin=subprocess.PIPE)
         os.dup2(stderr_tee_process.stdin.fileno(), sys.stderr.fileno())
 

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -9,6 +9,8 @@ from typing_extensions import Text
 import logging
 import sys
 import signal
+import subprocess
+import os
 
 log = logging.getLogger("calrissian.main")
 
@@ -24,6 +26,8 @@ def add_arguments(parser):
     parser.add_argument('--max-cores', type=str, help='Maximum number of CPU cores to use')
     parser.add_argument('--pod-labels', type=Text, nargs='?', help='YAML file of labels to add to Pods submitted')
     parser.add_argument('--usage-report', type=Text, nargs='?', help='Output JSON file name to record resource usage')
+    parser.add_argument('--stdout', type=Text, nargs='?', help='Output file name to tee standard output (CWL output object)')
+    parser.add_argument('--stderr', type=Text, nargs='?', help='Output file name to tee standard error to (includes tool logs)')
 
 
 def print_version():
@@ -57,11 +61,32 @@ def install_signal_handler():
     signal.signal(signal.SIGTERM, handle_sigterm)
 
 
+def install_tees(stdout_path=None, stderr_path=None):
+    """
+    Reconnects stdout/stderr to `tee` processes via subprocess.PIPE that can write to user-supplied files
+    https://stackoverflow.com/a/651718/595085
+    :param stdout_path: optional path of file to tee standard output to
+    :param stderr_path: optional path of file to tee standard error to
+    :return: None
+    """
+
+    if stdout_path:
+        sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+        stdout_tee_process = subprocess.Popen(["tee", stdout_path], stdin=subprocess.PIPE)
+        os.dup2(stdout_tee_process.stdin.fileno(), sys.stdout.fileno())
+
+    if stderr_path:
+        sys.stderr = os.fdopen(sys.stderr.fileno(), 'w', 0)
+        stderr_tee_process = subprocess.Popen(["tee", stderr_path], stdin=subprocess.PIPE)
+        os.dup2(stderr_tee_process.stdin.fileno(), sys.stderr.fileno())
+
+
 def main():
     activate_logging()
     parser = arg_parser()
     add_arguments(parser)
     parsed_args = parse_arguments(parser)
+    install_tees(parsed_args.stdout, parsed_args.stderr)
     max_ram_megabytes = MemoryParser.parse_to_megabytes(parsed_args.max_ram)
     max_cores = CPUParser.parse(parsed_args.max_cores)
     executor = CalrissianExecutor(max_ram_megabytes, max_cores)

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -75,7 +75,10 @@ def install_tees(stdout_path=None, stderr_path=None):
         os.dup2(stdout_tee_process.stdin.fileno(), sys.stdout.fileno())
 
     if stderr_path:
-        stderr_tee_process = subprocess.Popen(["tee", stderr_path], stdin=subprocess.PIPE)
+        # stderr must be handled differently. By default, tee sends output to stdout,
+        # so we run it under a shell to redirect that to stderr.
+        # subprocess.STDOUT can be used to redirect stderr to stdout but there's no convenience for the opposite
+        stderr_tee_process = subprocess.Popen(["sh", "-c", "tee >&2 \"{}\"".format(stderr_path)], stdin=subprocess.PIPE)
         os.dup2(stderr_tee_process.stdin.fileno(), sys.stderr.fileno())
 
 

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -11,8 +11,10 @@ import sys
 import signal
 import subprocess
 import os
+import shlex
 
 log = logging.getLogger("calrissian.main")
+
 
 def activate_logging():
     loggers = ['executor','context','tool','job', 'k8s','main']
@@ -76,9 +78,10 @@ def install_tees(stdout_path=None, stderr_path=None):
 
     if stderr_path:
         # stderr must be handled differently. By default, tee sends output to stdout,
-        # so we run it under a shell to redirect that to stderr.
-        # subprocess.STDOUT can be used to redirect stderr to stdout but there's no convenience for the opposite
-        stderr_tee_process = subprocess.Popen(["sh", "-c", "tee >&2 \"{}\"".format(stderr_path)], stdin=subprocess.PIPE)
+        # so we run it under a shell to redirect that to stderr, and use shlex.quote for safety
+        stderr_tee_process = subprocess.Popen(["tee >&2 {}".format(shlex.quote(stderr_path))],
+                                              stdin=subprocess.PIPE,
+                                              shell=True)
         os.dup2(stderr_tee_process.stdin.fileno(), sys.stderr.fileno())
 
 

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -71,14 +71,17 @@ def install_tees(stdout_path=None, stderr_path=None):
     """
 
     if stdout_path:
-        sys.stdout = os.fdopen(sys.stdout.fileno(), 'wb', 0)
         stdout_tee_process = subprocess.Popen(["tee", stdout_path], stdin=subprocess.PIPE)
         os.dup2(stdout_tee_process.stdin.fileno(), sys.stdout.fileno())
 
     if stderr_path:
-        sys.stderr = os.fdopen(sys.stderr.fileno(), 'wb', 0)
         stderr_tee_process = subprocess.Popen(["tee", stderr_path], stdin=subprocess.PIPE)
         os.dup2(stderr_tee_process.stdin.fileno(), sys.stderr.fileno())
+
+
+def flush_tees():
+    sys.stdout.flush()
+    sys.stderr.flush()
 
 
 def main():
@@ -106,6 +109,7 @@ def main():
         delete_pods()
         if parsed_args.usage_report:
             write_report(parsed_args.usage_report)
+        flush_tees()
 
     return result
 

--- a/openshift/CalrissianJob-revsort.yaml
+++ b/openshift/CalrissianJob-revsort.yaml
@@ -11,6 +11,10 @@ spec:
         image: calrissian:latest
         command: ["calrissian"]
         args:
+          - "--stdout"
+          - "/calrissian/output-data/revsort-output.json"
+          - "--stderr"
+          - "/calrissian/output-data/revsort-stderr.log"
           - "--max-ram"
           - "16G"
           - "--max-cores"


### PR DESCRIPTION
Adds optional command-line arguments to specify files for writing standard output and standard error

- If specified, these files are written by piping through `tee`, meaning that stdout/stderr still are written to the kubernetes pod logs, but also to the named files.
- This feature allows other tools that run calrissian in kubernetes (e.g. lando) to declare what files to write to, without a shell and without silencing job logs

Baseline functionality for #17