### PR TITLE
Sends CWL tool logging to calrissian debug / stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The `openshift/` directory contains YAML files that demonstrate the basic functi
 
         oc new-project calrissian-demo-project
 
-2. Create a role in your project to allow managing `Pod`s:
+2. Create a pair of roles in your project to allow managing kubernetes `pods` and `logs`:
 
         oc create role pod-manager-role --verb=create,delete,list,watch --resource=pods
         oc create role log-reader-role --verb=get,list --resource=pods/log

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ The `openshift/` directory contains YAML files that demonstrate the basic functi
 2. Create a role in your project to allow managing `Pod`s:
 
         oc create role pod-manager-role --verb=create,delete,list,watch --resource=pods
+        oc create role log-reader-role --verb=get,list --resource=pods/log
 
 3. Bind your project's default service account access to these roles. Calrissian running inside the cluster will use this service account to make Kubernetes API calls.
 
         oc create rolebinding pod-manager-default-binding --role=pod-manager-role --serviceaccount=calrissian-demo-project:default
+        oc create rolebinding log-reader-default-binding --role=log-reader-role --serviceaccount=calrissian-demo-project:default
 
 4. Create the BuildConfig - this allows Openshift to build the source code into a Docker image and starts a build automatically. If you wish to build a different branch or repo, edit this file.
 

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -117,8 +117,8 @@ class KubernetesClient(object):
     def follow_logs(self):
         pod_name = self.pod.metadata.name
         log.info('[{}] follow_logs start'.format(pod_name))
-        #             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
-        # _request timeout is either single-value total or (connect, read)
+        # _request timeout can either single-value for urllib3 total timeout or tuple of (connect, read)
+        # Appears that timeout is necessary for following logs to avoid timing out?
         for line in self.core_api_instance.read_namespaced_pod_log(self.pod.metadata.name, self.namespace, follow=True,
                                                                    _preload_content=False, _request_timeout=0, timestamps=True).stream():
             # .stream() is only available if _preload_content=False

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -124,7 +124,7 @@ class KubernetesClient(object):
             log.info('exiting log watcher for {}'.format(name))
 
         thread = threading.Thread(target=pod_log_watcher, args=(self.core_api_instance, self.pod.metadata.name, self.namespace))
-        thread.daemon = True
+        thread.daemon = True # Should not prevent calrissian from exiting otherwise.
         self.logging_thread = thread
         thread.start()
 
@@ -150,7 +150,7 @@ class KubernetesClient(object):
                 w.stop()
             else:
                 raise CalrissianJobException('Unexpected pod container status', status)
-        self.logging_thread.wait()
+        self.logging_thread.join()
         return self.completion_result
 
     def _set_pod(self, pod):

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -120,7 +120,7 @@ class KubernetesClient(object):
         # _request timeout can either single-value for urllib3 total timeout or tuple of (connect, read)
         # Appears that timeout is necessary for following logs to avoid timing out?
         for line in self.core_api_instance.read_namespaced_pod_log(self.pod.metadata.name, self.namespace, follow=True,
-                                                                   _preload_content=False, _request_timeout=0, timestamps=True).stream():
+                                                                   _preload_content=False, _request_timeout=0).stream():
             # .stream() is only available if _preload_content=False
             # .stream() returns a generator, each iteration yields bytes.
             # kubernetes-client decodes them as utf-8 when _preload_content is True

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -115,10 +115,11 @@ class KubernetesClient(object):
         log.info('handling completion with {}'.format(exit_code))
 
     def follow_logs(self):
-        log.info('starting follow_logs for {}'.format(self.pod.metadata.name))
+        pod_name = self.pod.metadata.name
+        log.info('[{}] follow_logs start'.format(pod_name))
         for line in self.core_api_instance.read_namespaced_pod_log(self.pod.metadata.name, self.namespace, follow=True, _preload_content=False).stream():
-            log.info('{}: {}'.format(name, line))
-        log.info('finishing follow_logs for {}'.format(self.pod.metadata.name))
+            log.debug('[{}] {}'.format(pod_name, line))
+        log.info('[{}] follow_logs end'.format(pod_name))
 
     def wait_for_completion(self):
         w = watch.Watch()

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -117,10 +117,8 @@ class KubernetesClient(object):
     def follow_logs(self):
         pod_name = self.pod.metadata.name
         log.info('[{}] follow_logs start'.format(pod_name))
-        # _request timeout can either single-value for urllib3 total timeout or tuple of (connect, read)
-        # Appears that timeout is necessary for following logs to avoid timing out?
         for line in self.core_api_instance.read_namespaced_pod_log(self.pod.metadata.name, self.namespace, follow=True,
-                                                                   _preload_content=False, _request_timeout=0).stream():
+                                                                   _preload_content=False).stream():
             # .stream() is only available if _preload_content=False
             # .stream() returns a generator, each iteration yields bytes.
             # kubernetes-client decodes them as utf-8 when _preload_content is True

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -117,8 +117,10 @@ class KubernetesClient(object):
     def follow_logs(self):
         pod_name = self.pod.metadata.name
         log.info('[{}] follow_logs start'.format(pod_name))
+        #             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
+        # _request timeout is either single-value total or (connect, read)
         for line in self.core_api_instance.read_namespaced_pod_log(self.pod.metadata.name, self.namespace, follow=True,
-                                                                   _preload_content=False, timestamps=True).stream():
+                                                                   _preload_content=False, _request_timeout=0, timestamps=True).stream():
             # .stream() is only available if _preload_content=False
             # .stream() returns a generator, each iteration yields bytes.
             # kubernetes-client decodes them as utf-8 when _preload_content is True

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -259,7 +259,7 @@ class KubernetesClientTestCase(TestCase):
         self.assertTrue(mock_read.called)
         self.assertEqual(mock_read.call_args, call('logging-pod-123', 'logging-ns',
                                                    follow=True, _preload_content=False,
-                                                   _request_timeout=0, timestamps=True))
+                                                   _request_timeout=0))
         self.assertEqual(mock_log.debug.mock_calls, [
             call('[logging-pod-123] line1'),
             call('[logging-pod-123] line2')

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -258,8 +258,7 @@ class KubernetesClientTestCase(TestCase):
         kc.follow_logs()
         self.assertTrue(mock_read.called)
         self.assertEqual(mock_read.call_args, call('logging-pod-123', 'logging-ns',
-                                                   follow=True, _preload_content=False,
-                                                   _request_timeout=0))
+                                                   follow=True, _preload_content=False))
         self.assertEqual(mock_log.debug.mock_calls, [
             call('[logging-pod-123] line1'),
             call('[logging-pod-123] line2')

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -65,7 +65,7 @@ class KubernetesClientTestCase(TestCase):
     def make_mock_pod(self, name):
         mock_metadata = Mock()
         # Cannot mock name attribute without a propertymock
-        name_property = PropertyMock(return_value='test123')
+        name_property = PropertyMock(return_value=name)
         type(mock_metadata).name = name_property
         mock_pod = create_autospec(V1Pod, metadata=mock_metadata)
         return mock_pod
@@ -93,8 +93,9 @@ class KubernetesClientTestCase(TestCase):
         self.assertIsNotNone(kc.pod)
 
     @patch('calrissian.k8s.watch')
-    def test_wait_skips_pod_when_state_is_running(self, mock_watch, mock_get_namespace, mock_client):
+    def test_wait_skips_pod_when_state_is_waiting(self, mock_watch, mock_get_namespace, mock_client):
         mock_pod = create_autospec(V1Pod)
+        mock_pod.status.container_statuses[0].state = Mock(running=None, waiting=True, terminated=None)
         self.setup_mock_watch(mock_watch, [mock_pod])
         kc = KubernetesClient()
         kc._set_pod(Mock())
@@ -102,6 +103,20 @@ class KubernetesClientTestCase(TestCase):
         self.assertFalse(mock_watch.Watch.return_value.stop.called)
         self.assertFalse(mock_client.CoreV1Api.return_value.delete_namespaced_pod.called)
         self.assertIsNotNone(kc.pod)
+
+    @patch('calrissian.k8s.watch')
+    @patch('calrissian.k8s.KubernetesClient.follow_logs')
+    def test_wait_follows_logs_pod_when_state_is_running(self, mock_follow_logs, mock_watch, mock_get_namespace, mock_client):
+        mock_pod = create_autospec(V1Pod)
+        mock_pod.status.container_statuses[0].state = Mock(running=True, waiting=None, terminated=None)
+        self.setup_mock_watch(mock_watch, [mock_pod])
+        kc = KubernetesClient()
+        kc._set_pod(Mock())
+        kc.wait_for_completion()
+        self.assertFalse(mock_watch.Watch.return_value.stop.called)
+        self.assertFalse(mock_client.CoreV1Api.return_value.delete_namespaced_pod.called)
+        self.assertIsNotNone(kc.pod)
+        self.assertTrue(mock_follow_logs.called)
 
     @patch('calrissian.k8s.watch')
     @patch('calrissian.k8s.PodMonitor')
@@ -230,6 +245,29 @@ class KubernetesClientTestCase(TestCase):
         with self.assertRaises(CalrissianJobException) as context:
             kc.delete_pod_name('pod-123')
         self.assertIn('Error deleting pod named pod-123', str(context.exception))
+
+    @patch('calrissian.k8s.log')
+    def test_follow_logs_streams_to_logging(self, mock_log, mock_get_namespace, mock_client):
+        mock_get_namespace.return_value = 'logging-ns'
+        mock_read = mock_client.CoreV1Api.return_value.read_namespaced_pod_log
+        mock_read.return_value.stream.return_value = [b'line1\n', b'line2\n']
+        mock_pod = self.make_mock_pod('logging-pod-123')
+        kc = KubernetesClient()
+        kc._set_pod(mock_pod)
+        mock_log.reset_mock() # log will have other calls before calling follow_logs()
+        kc.follow_logs()
+        self.assertTrue(mock_read.called)
+        self.assertEqual(mock_read.call_args, call('logging-pod-123', 'logging-ns',
+                                                   follow=True, _preload_content=False,
+                                                   _request_timeout=0, timestamps=True))
+        self.assertEqual(mock_log.debug.mock_calls, [
+            call('[logging-pod-123] line1'),
+            call('[logging-pod-123] line2')
+            ])
+        self.assertEqual(mock_log.info.mock_calls, [
+            call('[logging-pod-123] follow_logs start'),
+            call('[logging-pod-123] follow_logs end')
+        ])
 
 
 class KubernetesClientStateTestCase(TestCase):

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -241,8 +241,13 @@ class KubernetesClientStateTestCase(TestCase):
 
     def test_is_running(self):
         self.assertTrue(KubernetesClient.state_is_running(self.running_state))
-        self.assertTrue(KubernetesClient.state_is_running(self.waiting_state))
+        self.assertFalse(KubernetesClient.state_is_running(self.waiting_state))
         self.assertFalse(KubernetesClient.state_is_running(self.terminated_state))
+
+    def test_is_waiting(self):
+        self.assertFalse(KubernetesClient.state_is_waiting(self.running_state))
+        self.assertTrue(KubernetesClient.state_is_waiting(self.waiting_state))
+        self.assertFalse(KubernetesClient.state_is_waiting(self.terminated_state))
 
     def test_is_terminated(self):
         self.assertFalse(KubernetesClient.state_is_terminated(self.running_state))

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -422,7 +422,8 @@ class ReporterFunctionsTestCase(TestCase):
         initialize_reporter(0, 0)
         self.assertIsNotNone(Reporter.get_report())
 
-    def test_write_report_raises_if_not_initialized(self):
+    @patch('builtins.open')
+    def test_write_report_raises_if_not_initialized(self, mock_open):
         Reporter.timeline_report = None
         self.assertIsNone(Reporter.get_report())
         with self.assertRaises(AttributeError) as context:


### PR DESCRIPTION
- After submitting a pod, follows stream of logs using `read_namespaced_pod_log()`
- Sends log lines to `log.debug()`, prefixed with the name of the pod in square brackets
- Also fixes a couple of stray test bugs found along the way

Fixes #17 