### PR TITLE
Adds storage usage and job name to each step in usage report

### DIFF
--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -304,13 +304,12 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
     def wait_for_kubernetes_pod(self):
         return self.client.wait_for_completion()
 
-    def report(self, completion_result, bytes_written):
+    def report(self, completion_result, disk_bytes):
         """
         Convert the k8s-specific completion result into a report and submit it
         :param completion_result: calrissian.k8s.CompletionResult
         """
-        report = TimedResourceReport.from_completion_result(completion_result)
-        report.bytes_written = bytes_written
+        report = TimedResourceReport.from_completion_result(completion_result, disk_bytes)
         Reporter.add_report(report)
 
     def finish(self, completion_result, runtimeContext):
@@ -328,8 +327,8 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
         # collect_outputs (and collect_output) is defined in command_line_tool
         outputs = self.collect_outputs(self.outdir)
 
-        bytes_written = total_size(outputs)
-        self.report(completion_result, bytes_written)
+        disk_bytes = total_size(outputs)
+        self.report(completion_result, disk_bytes)
 
         # Invoke the callback with a lock
         with runtimeContext.workflow_eval_lock:

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -309,7 +309,7 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
         Convert the k8s-specific completion result into a report and submit it
         :param completion_result: calrissian.k8s.CompletionResult
         """
-        report = TimedResourceReport.from_completion_result(completion_result, disk_bytes)
+        report = TimedResourceReport.create(self.name, completion_result, disk_bytes)
         Reporter.add_report(report)
 
     def finish(self, completion_result, runtimeContext):

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -2,7 +2,7 @@ from cwltool.job import ContainerCommandLineJob, needs_shell_quoting_re
 from cwltool.utils import DEFAULT_TMP_PREFIX
 from cwltool.errors import WorkflowException, UnsupportedRequirement
 from calrissian.k8s import KubernetesClient
-from calrissian.report import Reporter, TimedResourceReport, CPUParser, MemoryParser
+from calrissian.report import Reporter, TimedResourceReport
 import logging
 import os
 import yaml
@@ -12,7 +12,7 @@ import random
 import string
 import shellescape
 from cwltool.pathmapper import ensure_writable, ensure_non_writable
-import json
+from cwltool.utils import visit_class
 
 log = logging.getLogger("calrissian.job")
 
@@ -44,6 +44,18 @@ def random_tag(length=8):
 def read_yaml(filename):
     with open(filename) as f:
         return yaml.safe_load(f)
+
+
+def total_size(outputs):
+    """
+    Recursively walk through an output dictionary object, totaling
+    up file size from each dictionary where 'class' == 'File'
+    :param outputs: output dictionary from a CWL job
+    :return: Sum of all 'size' field values found
+    """
+    files = []
+    visit_class(outputs, ("File",), files.append)
+    return sum([f.get('size') for f in files])
 
 
 class KubernetesPodVolumeInspector(object):
@@ -292,15 +304,17 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
     def wait_for_kubernetes_pod(self):
         return self.client.wait_for_completion()
 
-    def report(self, completion_result):
+    def report(self, completion_result, bytes_written):
         """
         Convert the k8s-specific completion result into a report and submit it
         :param completion_result: calrissian.k8s.CompletionResult
         """
         report = TimedResourceReport.from_completion_result(completion_result)
+        report.bytes_written = bytes_written
         Reporter.add_report(report)
 
-    def finish(self, exit_code, runtimeContext):
+    def finish(self, completion_result, runtimeContext):
+        exit_code = completion_result.exit_code
         if exit_code in self.successCodes:
             status = "success"
         elif exit_code in self.temporaryFailCodes:
@@ -313,14 +327,15 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
             status = "permanentFail"
         # collect_outputs (and collect_output) is defined in command_line_tool
         outputs = self.collect_outputs(self.outdir)
-        json_outputs = json.dumps(outputs, indent=4)
-        log.debug('{} - collected outputs:\n{}'.format(self.name, json_outputs))
 
-        # report the outputs with workflow lock
+        bytes_written = total_size(outputs)
+        self.report(completion_result, bytes_written)
+
+        # Invoke the callback with a lock
         with runtimeContext.workflow_eval_lock:
             self.output_callback(outputs, status)
 
-        # Required cleanup
+        # Cleanup our stagedir and tmp
         if self.stagedir is not None and os.path.exists(self.stagedir):
             log.debug('shutil.rmtree({}, {})'.format(self.stagedir, True))
             shutil.rmtree(self.stagedir, True)
@@ -504,8 +519,7 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
         pod = self.create_kubernetes_runtime(runtimeContext) # analogous to create_runtime()
         self.execute_kubernetes_pod(pod) # analogous to _execute()
         completion_result = self.wait_for_kubernetes_pod()
-        self.report(completion_result)
-        self.finish(completion_result.exit_code, runtimeContext)
+        self.finish(completion_result, runtimeContext)
 
     # Below are concrete implementations of the remaining abstract methods in ContainerCommandLineJob
     # They are not implemented and not expected to be called, so they all raise NotImplementedError
@@ -528,4 +542,3 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
     @staticmethod
     def append_volume(runtime, source, target, writable=False):
         raise NotImplementedError('append_volume')
-

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -55,7 +55,9 @@ def total_size(outputs):
     """
     files = []
     visit_class(outputs, ("File",), files.append)
-    return sum([f.get('size') for f in files])
+    # Per https://www.commonwl.org/v1.0/CommandLineTool.html#File
+    # size is optional in the class, so default to 0 if not found
+    return sum([f.get('size', 0) for f in files])
 
 
 class KubernetesPodVolumeInspector(object):

--- a/calrissian/report.py
+++ b/calrissian/report.py
@@ -105,9 +105,10 @@ class TimedResourceReport(TimedReport):
     duration of the timed report. These values, by convention, are the kubernetes **requested**
     resources (not limits or actual).
     """
-    def __init__(self, cpus=0, ram_megabytes=0, *args, **kwargs):
+    def __init__(self, cpus=0, ram_megabytes=0, bytes_written=0, *args, **kwargs):
         self.cpus = cpus
         self.ram_megabytes = ram_megabytes
+        self.bytes_written = 0
         super(TimedResourceReport, self).__init__(*args, **kwargs)
 
     def ram_megabyte_hours(self):
@@ -120,6 +121,7 @@ class TimedResourceReport(TimedReport):
         result = super(TimedResourceReport, self).to_dict()
         result['ram_megabyte_hours'] = self.ram_megabyte_hours()
         result['cpu_hours'] = self.cpu_hours()
+        result['bytes_written'] = self.bytes_written
         return result
 
     @classmethod

--- a/calrissian/report.py
+++ b/calrissian/report.py
@@ -14,7 +14,7 @@ class TimedReport(object):
     """
 
     def __init__(self, name=None, start_time=None, finish_time=None):
-        self.name = None
+        self.name = name
         self.start_time = start_time
         self.finish_time = finish_time
 

--- a/calrissian/report.py
+++ b/calrissian/report.py
@@ -13,7 +13,8 @@ class TimedReport(object):
     Report on operations with a specific start time and finish time.
     """
 
-    def __init__(self, start_time=None, finish_time=None):
+    def __init__(self, name=None, start_time=None, finish_time=None):
+        self.name = None
         self.start_time = start_time
         self.finish_time = finish_time
 
@@ -124,11 +125,11 @@ class TimedResourceReport(TimedReport):
         return result
 
     @classmethod
-    def from_completion_result(cls, result, disk_bytes):
-        cpus = CPUParser.parse(result.cpus)
-        ram_megabytes = MemoryParser.parse_to_megabytes(result.memory)
+    def create(cls, name, completion_result, disk_bytes):
+        cpus = CPUParser.parse(completion_result.cpus)
+        ram_megabytes = MemoryParser.parse_to_megabytes(completion_result.memory)
         disk_megabytes = MemoryParser.parse_to_megabytes(str(disk_bytes))
-        return cls(start_time=result.start_time, finish_time=result.finish_time, cpus=cpus,
+        return cls(name=name, start_time=completion_result.start_time, finish_time=completion_result.finish_time, cpus=cpus,
                    ram_megabytes=ram_megabytes, disk_megabytes=disk_megabytes)
 
 
@@ -253,6 +254,9 @@ class TimelineReport(TimedReport):
     def total_ram_megabyte_hours(self):
         return sum([child.ram_megabyte_hours() for child in self.children])
 
+    def total_disk_megabytes(self):
+        return sum([child.disk_megabytes for child in self.children])
+
     def total_tasks(self):
         return len(self.children)
 
@@ -293,6 +297,7 @@ class TimelineReport(TimedReport):
         result = super(TimelineReport, self).to_dict()
         result['total_cpu_hours'] = self.total_cpu_hours()
         result['total_ram_megabyte_hours'] = self.total_ram_megabyte_hours()
+        result['total_disk_megabytes'] = self.total_disk_megabytes()
         result['total_tasks'] = self.total_tasks()
         result['max_parallel_cpus'] = self.max_parallel_cpus()
         result['max_parallel_ram_megabytes'] = self.max_parallel_ram_megabytes()

--- a/calrissian/report.py
+++ b/calrissian/report.py
@@ -101,14 +101,14 @@ class CPUParser(ResourceParser):
 
 class TimedResourceReport(TimedReport):
     """
-    Adds CPU and memory values to TimedReport, in order to calculate resource usage over the
+    Adds CPU, memory, and disk values to TimedReport, in order to calculate resource usage over the
     duration of the timed report. These values, by convention, are the kubernetes **requested**
     resources (not limits or actual).
     """
-    def __init__(self, cpus=0, ram_megabytes=0, bytes_written=0, *args, **kwargs):
+    def __init__(self, cpus=0, ram_megabytes=0, disk_megabytes=0, *args, **kwargs):
         self.cpus = cpus
         self.ram_megabytes = ram_megabytes
-        self.bytes_written = 0
+        self.disk_megabytes = disk_megabytes
         super(TimedResourceReport, self).__init__(*args, **kwargs)
 
     def ram_megabyte_hours(self):
@@ -121,14 +121,15 @@ class TimedResourceReport(TimedReport):
         result = super(TimedResourceReport, self).to_dict()
         result['ram_megabyte_hours'] = self.ram_megabyte_hours()
         result['cpu_hours'] = self.cpu_hours()
-        result['bytes_written'] = self.bytes_written
         return result
 
     @classmethod
-    def from_completion_result(cls, result):
+    def from_completion_result(cls, result, disk_bytes):
         cpus = CPUParser.parse(result.cpus)
         ram_megabytes = MemoryParser.parse_to_megabytes(result.memory)
-        return cls(start_time=result.start_time, finish_time=result.finish_time, cpus=cpus, ram_megabytes=ram_megabytes)
+        disk_megabytes = MemoryParser.parse_to_megabytes(str(disk_bytes))
+        return cls(start_time=result.start_time, finish_time=result.finish_time, cpus=cpus,
+                   ram_megabytes=ram_megabytes, disk_megabytes=disk_megabytes)
 
 
 class Event(object):

--- a/calrissian/report.py
+++ b/calrissian/report.py
@@ -43,7 +43,8 @@ class TimedReport(object):
             return None
 
     def to_dict(self):
-        result = dict(vars(self)) # Make sure we create a copy, otherwise writing to the dict overwrites the object
+        # Create a dict of our variables, filtering out None
+        result = dict((k,v) for k,v in vars(self).items() if v is not None)
         result['elapsed_hours'] = self.elapsed_hours()
         result['elapsed_seconds'] = self.elapsed_seconds()
         return result

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -384,7 +384,6 @@ class CalrissianCommandLineJobTestCase(TestCase):
         self.assertTrue(job.collect_outputs.called)
         job.output_callback.assert_called_with(mock_collected_outputs, 'success')
 
-
     @patch('calrissian.job.Reporter')
     def test_finish_looks_up_codes(self, mock_reporter, mock_volume_builder, mock_client):
         job = self.make_job()
@@ -408,6 +407,15 @@ class CalrissianCommandLineJobTestCase(TestCase):
             completion_result = self.make_completion_result(code)
             job.finish(completion_result, self.runtime_context)
             job.output_callback.assert_called_with(mock_collected_outputs, status)
+
+    def test_finish_removes_stagedir(self, mock_volume_builder, mock_client):
+        self.fail('Not implemented')
+
+    def test_finish_removes_tmpdir(self, mock_volume_builder, mock_client):
+        self.fail('Not implemented')
+
+    def test_finish_leaves_tmpdir(self, mock_volume_builder, mock_client):
+        self.fail('Not implemented')
 
     def test__get_container_image_docker_pull(self, mock_volume_builder, mock_client):
         job = self.make_job()

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 from calrissian.report import TimedReport, TimedResourceReport, TimelineReport
 from calrissian.report import Event, MaxParallelCountProcessor, MaxParallelCPUsProcessor, MaxParallelRAMProcessor
 from calrissian.report import MemoryParser, CPUParser, Reporter
-from calrissian.report import initialize_reporter, write_report, default_serializer
+from calrissian.report import initialize_reporter, write_report, default_serializer, sum_ignore_none
 from calrissian.k8s import CompletionResult
 from freezegun import freeze_time
 from unittest.mock import Mock, call, patch
@@ -50,16 +50,14 @@ class TimedReportTestCase(TestCase):
         self.report.finish_time = TIME_1100
         self.assertEqual(1.0, self.report.elapsed_hours())
 
-    def test_elapsed_raises_if_not_started(self):
-        self.assertEqual(self.report.start_time, None)
-        with self.assertRaises(TypeError):
-            self.report.elapsed_seconds()
+    def test_elapsed_is_none_if_not_started(self):
+        self.assertIsNone(self.report.start_time)
+        self.assertIsNone(self.report.elapsed_seconds())
 
-    def test_elapsed_raises_if_not_finished(self):
+    def test_elapsed_is_none_if_not_finished(self):
         self.report.start()
-        self.assertEqual(self.report.finish_time, None)
-        with self.assertRaises(TypeError):
-            self.report.elapsed_seconds()
+        self.assertIsNone(self.report.finish_time)
+        self.assertIsNone(self.report.elapsed_seconds())
 
     def test_elapsed_raises_if_negative(self):
         self.report.start_time = TIME_1100
@@ -167,9 +165,8 @@ class TimelineReportTestCase(TestCase):
         self.report.add_report(TimedResourceReport(start_time=TIME_1045, finish_time=TIME_1100))
         self.assertEqual(self.report.elapsed_hours(), 1.0)
 
-    def test_elapsed_raises_with_no_tasks(self):
-        with self.assertRaises(TypeError):
-            self.report.elapsed_seconds()
+    def test_elapsed_is_none_with_no_tasks(self):
+        self.assertIsNone(self.report.elapsed_seconds())
 
     def test_max_parallel_tasks(self):
         # Count task parallelism. 3 total tasks, but only 2 at a given time
@@ -454,3 +451,24 @@ class ReporterFunctionsTestCase(TestCase):
         with self.assertRaises(TypeError) as context:
             default_serializer('other')
         self.assertIn('not serializable', str(context.exception))
+
+    @patch('builtins.open')
+    @patch('calrissian.report.json')
+    def test_write_report_recovers(self, mock_json, mock_open):
+        initialize_reporter(128, 4)
+        Reporter.add_report(TimedResourceReport(cpus=1, ram_megabytes=128))
+        write_report('output.json')
+        self.assertEqual(mock_open.call_args, call('output.json', 'w'))
+        self.assertTrue(mock_json.dump.called)
+
+
+class SumIgnoreNoneTestCase(TestCase):
+
+    def test_sum(self):
+        self.assertEqual(sum_ignore_none([1,2,3]), 6)
+
+    def test_drops_none(self):
+        self.assertEqual(sum_ignore_none([1,2,None]), 3)
+
+    def test_nones_become_zero(self):
+        self.assertEqual(sum_ignore_none([None,None,False]), 0)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -73,6 +73,10 @@ class TimedReportTestCase(TestCase):
         self.assertEqual(report_dict['elapsed_seconds'], 3600.0)
         self.assertEqual(report_dict['elapsed_hours'], 1.0)
 
+    def test_to_dict_drops_none(self):
+        self.assertIsNone(self.report.name)
+        report_dict = self.report.to_dict()
+        self.assertNotIn('name', report_dict)
 
 class TimedResourceReportTestCase(TestCase):
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -95,13 +95,17 @@ class TimedResourceReportTestCase(TestCase):
         self.assertEqual(self.report.ram_megabytes, 0)
         self.assertEqual(self.report.cpus, 0)
 
-    def test_from_completion_result(self):
+    def test_create(self):
         completion_result = CompletionResult(0, '4', '3G', TIME_1000, TIME_1100)
-        report = TimedResourceReport.from_completion_result(completion_result)
+        name = 'test-job'
+        disk_bytes = 10000
+        report = TimedResourceReport.create(name, completion_result, disk_bytes)
         self.assertEqual(report.cpu_hours(), 4)
         self.assertEqual(report.ram_megabyte_hours(), 3000)
         self.assertEqual(report.start_time, TIME_1000)
         self.assertEqual(report.finish_time, TIME_1100)
+        self.assertEqual(report.name, 'test-job')
+        self.assertEqual(report.disk_megabytes, 10)
 
     def test_to_dict(self):
         self.report.ram_megabytes = 1024

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -98,7 +98,7 @@ class TimedResourceReportTestCase(TestCase):
     def test_create(self):
         completion_result = CompletionResult(0, '4', '3G', TIME_1000, TIME_1100)
         name = 'test-job'
-        disk_bytes = 10000
+        disk_bytes = 10000000
         report = TimedResourceReport.create(name, completion_result, disk_bytes)
         self.assertEqual(report.cpu_hours(), 4)
         self.assertEqual(report.ram_megabyte_hours(), 3000)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -79,7 +79,7 @@ class TimedReportTestCase(TestCase):
 class TimedResourceReportTestCase(TestCase):
 
     def setUp(self):
-        self.report = TimedResourceReport(start_time=TIME_1000, finish_time=TIME_1015)
+        self.report = TimedResourceReport(name='timed-resource-report', start_time=TIME_1000, finish_time=TIME_1015)
 
     def test_calculates_ram_hours(self):
         # 1024MB for 15 minutes is 256 MB-hours
@@ -109,12 +109,15 @@ class TimedResourceReportTestCase(TestCase):
 
     def test_to_dict(self):
         self.report.ram_megabytes = 1024
+        self.report.disk_megabytes = 512
         self.report.cpus = 8
         report_dict = self.report.to_dict()
         self.assertEqual(report_dict['start_time'], TIME_1000)
         self.assertEqual(report_dict['finish_time'], TIME_1015)
         self.assertEqual(report_dict['cpu_hours'], 2)
         self.assertEqual(report_dict['ram_megabyte_hours'], 256)
+        self.assertEqual(report_dict['disk_megabytes'], 512)
+        self.assertEqual(report_dict['name'], 'timed-resource-report')
 
 
 class TimelineReportTestCase(TestCase):


### PR DESCRIPTION
- Reworks `CalrissianCommandLineJob.finish()` to add the size of files written and the job's name to the report entry
- Updates `CalrissianCommandLineJob.finish()` to call back in a thread safe manner and clean-up tmpdir/stagedir according to cwltool's implementation
- Updates reporting to include disk megabytes written and name per task, as well as a total megabytes written by all steps
- Refines behavior in reporting to eliminate reporting exceptions from incomplete jobs  (#58)

Fixes #53 
Fixes #58 