### PR TITLE
Use emptyDir for '/tmp' inside containers

### DIFF
--- a/openshift/CalrissianJob-fail-wf.yaml
+++ b/openshift/CalrissianJob-fail-wf.yaml
@@ -14,8 +14,6 @@ spec:
           - "1G"
           - "--max-cores"
           - "2"
-          - "--tmpdir-prefix"
-          - "/calrissian/tmptmp/"
           - "--tmp-outdir-prefix"
           - "/calrissian/tmpout/"
           - "--outdir"
@@ -27,8 +25,6 @@ spec:
           name: calrissian-input-data
         - mountPath: /calrissian/tmpout
           name: calrissian-tmpout
-        - mountPath: /calrissian/tmptmp
-          name: calrissian-tmp
         - mountPath: /calrissian/output-data
           name: calrissian-output-data
         env:
@@ -44,9 +40,6 @@ spec:
       - name: calrissian-tmpout
         persistentVolumeClaim:
           claimName: calrissian-tmpout
-      - name: calrissian-tmp
-        persistentVolumeClaim:
-          claimName: calrissian-tmp
       - name: calrissian-output-data
         persistentVolumeClaim:
           claimName: calrissian-output-data

--- a/openshift/CalrissianJob-revsort-single-default-container.yaml
+++ b/openshift/CalrissianJob-revsort-single-default-container.yaml
@@ -17,8 +17,6 @@ spec:
           - "16G"
           - "--max-cores"
           - "8"
-          - "--tmpdir-prefix"
-          - "/calrissian/tmptmp/"
           - "--tmp-outdir-prefix"
           - "/calrissian/tmpout/"
           - "--outdir"
@@ -30,8 +28,6 @@ spec:
           name: calrissian-input-data
         - mountPath: /calrissian/tmpout
           name: calrissian-tmpout
-        - mountPath: /calrissian/tmptmp
-          name: calrissian-tmp
         - mountPath: /calrissian/output-data
           name: calrissian-output-data
         env:
@@ -47,9 +43,6 @@ spec:
       - name: calrissian-tmpout
         persistentVolumeClaim:
           claimName: calrissian-tmpout
-      - name: calrissian-tmp
-        persistentVolumeClaim:
-          claimName: calrissian-tmp
       - name: calrissian-output-data
         persistentVolumeClaim:
           claimName: calrissian-output-data

--- a/openshift/CalrissianJob-revsort-single.yaml
+++ b/openshift/CalrissianJob-revsort-single.yaml
@@ -15,8 +15,6 @@ spec:
           - "16G"
           - "--max-cores"
           - "8"
-          - "--tmpdir-prefix"
-          - "/calrissian/tmptmp/"
           - "--tmp-outdir-prefix"
           - "/calrissian/tmpout/"
           - "--outdir"
@@ -28,8 +26,6 @@ spec:
           name: calrissian-input-data
         - mountPath: /calrissian/tmpout
           name: calrissian-tmpout
-        - mountPath: /calrissian/tmptmp
-          name: calrissian-tmp
         - mountPath: /calrissian/output-data
           name: calrissian-output-data
         env:
@@ -45,9 +41,6 @@ spec:
       - name: calrissian-tmpout
         persistentVolumeClaim:
           claimName: calrissian-tmpout
-      - name: calrissian-tmp
-        persistentVolumeClaim:
-          claimName: calrissian-tmp
       - name: calrissian-output-data
         persistentVolumeClaim:
           claimName: calrissian-output-data

--- a/openshift/CalrissianJob-revsort.yaml
+++ b/openshift/CalrissianJob-revsort.yaml
@@ -14,13 +14,11 @@ spec:
           - "--stdout"
           - "/calrissian/output-data/revsort-output.json"
           - "--stderr"
-          - "/calrissian/output-data/revsort-stderr.log"
+         - "/calrissian/output-data/revsort-stderr.log"
           - "--max-ram"
           - "16G"
           - "--max-cores"
           - "8"
-          - "--tmpdir-prefix"
-          - "/calrissian/tmptmp/"
           - "--tmp-outdir-prefix"
           - "/calrissian/tmpout/"
           - "--outdir"
@@ -34,8 +32,6 @@ spec:
           name: calrissian-input-data
         - mountPath: /calrissian/tmpout
           name: calrissian-tmpout
-        - mountPath: /calrissian/tmptmp
-          name: calrissian-tmp
         - mountPath: /calrissian/output-data
           name: calrissian-output-data
         env:
@@ -51,9 +47,6 @@ spec:
       - name: calrissian-tmpout
         persistentVolumeClaim:
           claimName: calrissian-tmpout
-      - name: calrissian-tmp
-        persistentVolumeClaim:
-          claimName: calrissian-tmp
       - name: calrissian-output-data
         persistentVolumeClaim:
           claimName: calrissian-output-data

--- a/openshift/CalrissianJob-revsort.yaml
+++ b/openshift/CalrissianJob-revsort.yaml
@@ -14,7 +14,7 @@ spec:
           - "--stdout"
           - "/calrissian/output-data/revsort-output.json"
           - "--stderr"
-         - "/calrissian/output-data/revsort-stderr.log"
+          - "/calrissian/output-data/revsort-stderr.log"
           - "--max-ram"
           - "16G"
           - "--max-cores"

--- a/openshift/VolumeClaims.yaml
+++ b/openshift/VolumeClaims.yaml
@@ -23,17 +23,6 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: calrissian-tmp
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 1Gi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
   name: calrissian-output-data
 spec:
   accessModes:


### PR DESCRIPTION
- Updates KubernetesVolumeBuilder to support a list of named emptyDir volumes
- Updates CalrissianCommandLineJob.create_kubernetes_runtime to use an emptyDir volume for '/tmp' inside the container

Upon implementation, I don't think this will conflict with any of the special cases mentioned in #30 (writable files being copied into /tmp). These files are copied on the calrissian host and mounted later (via `add_volumes()`). This change will mount the base `/tmp` as an `emptyDir` but additional direct mounts to files placed by calrissian shouldn't be impacted.

tl;dr - this is a simple fix for #30 that shouldn't break the existing special cases (that we don't use anyway)

Fixes #30