### PR TITLE
Specify urllib3 to be a compatible version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     author_email='dan.leehr@duke.edu',
     description='CWL runner for Kubernetes',
     install_requires=[
+        'urllib3<1.25,>=1.24.2',
         'kubernetes==8.0.1',
         'cwltool==1.0.20181217162649',
     ],


### PR DESCRIPTION
Requests requires a specific range of urllib3 versions, but kubernetes is less picky and installed an incompatible version. This change specifies a version of urllib3 compatible with everyone as the first required package in setup.py