### PR TITLE
Include volume readOnly state when passing along volumes

### DIFF
--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -75,7 +75,7 @@ class KubernetesPodVolumeInspector(object):
         for pod_volume in self.pod.spec.volumes:
             if pod_volume.persistent_volume_claim:
                 claim_name = pod_volume.persistent_volume_claim.claim_name
-                read_only = pod_volume.persistent_volume_claim.read_only
+                read_only = pod_volume.persistent_volume_claim.read_only or False
                 persistent_volumes[pod_volume.name] = (claim_name, read_only)
         return persistent_volumes
 

--- a/examples/CalrissianJob-fail-wf.yaml
+++ b/examples/CalrissianJob-fail-wf.yaml
@@ -23,6 +23,7 @@ spec:
         volumeMounts:
         - mountPath: /calrissian/input-data
           name: calrissian-input-data
+          readOnly: true
         - mountPath: /calrissian/tmpout
           name: calrissian-tmpout
         - mountPath: /calrissian/output-data
@@ -37,6 +38,7 @@ spec:
       - name: calrissian-input-data
         persistentVolumeClaim:
           claimName: calrissian-input-data
+          readOnly: true
       - name: calrissian-tmpout
         persistentVolumeClaim:
           claimName: calrissian-tmpout

--- a/examples/CalrissianJob-revsort-single-default-container.yaml
+++ b/examples/CalrissianJob-revsort-single-default-container.yaml
@@ -26,6 +26,7 @@ spec:
         volumeMounts:
         - mountPath: /calrissian/input-data
           name: calrissian-input-data
+          readOnly: true
         - mountPath: /calrissian/tmpout
           name: calrissian-tmpout
         - mountPath: /calrissian/output-data
@@ -40,6 +41,7 @@ spec:
       - name: calrissian-input-data
         persistentVolumeClaim:
           claimName: calrissian-input-data
+          readOnly: true
       - name: calrissian-tmpout
         persistentVolumeClaim:
           claimName: calrissian-tmpout

--- a/examples/CalrissianJob-revsort-single.yaml
+++ b/examples/CalrissianJob-revsort-single.yaml
@@ -24,6 +24,7 @@ spec:
         volumeMounts:
         - mountPath: /calrissian/input-data
           name: calrissian-input-data
+          readOnly: true
         - mountPath: /calrissian/tmpout
           name: calrissian-tmpout
         - mountPath: /calrissian/output-data
@@ -38,6 +39,7 @@ spec:
       - name: calrissian-input-data
         persistentVolumeClaim:
           claimName: calrissian-input-data
+          readOnly: true
       - name: calrissian-tmpout
         persistentVolumeClaim:
           claimName: calrissian-tmpout

--- a/examples/CalrissianJob-revsort.yaml
+++ b/examples/CalrissianJob-revsort.yaml
@@ -30,6 +30,7 @@ spec:
         volumeMounts:
         - mountPath: /calrissian/input-data
           name: calrissian-input-data
+          readOnly: true
         - mountPath: /calrissian/tmpout
           name: calrissian-tmpout
         - mountPath: /calrissian/output-data
@@ -44,6 +45,7 @@ spec:
       - name: calrissian-input-data
         persistentVolumeClaim:
           claimName: calrissian-input-data
+          readOnly: true
       - name: calrissian-tmpout
         persistentVolumeClaim:
           claimName: calrissian-tmpout

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -49,16 +49,16 @@ class KubernetesPodVolumeInspectorTestCase(TestCase):
         kpod = KubernetesPodVolumeInspector(mock_pod)
         mock_data1_volume = Mock()
         mock_data1_volume.name = 'data1'
-        mock_data1_volume.persistent_volume_claim = Mock(claim_name='data1-claim-name')
+        mock_data1_volume.persistent_volume_claim = Mock(claim_name='data1-claim-name', read_only=False)
         mock_data2_volume = Mock()
         mock_data2_volume.name = 'data2'
-        mock_data2_volume.persistent_volume_claim = Mock(claim_name='data2-claim-name')
+        mock_data2_volume.persistent_volume_claim = Mock(claim_name='data2-claim-name', read_only=False)
 
         mock_ignored_volume = Mock(persistent_volume_claim=Mock())
         mock_pod.spec.volumes = [mock_data1_volume, mock_data2_volume]
         expected_dict = {
-            'data1': 'data1-claim-name',
-            'data2': 'data2-claim-name',
+            'data1': ('data1-claim-name', False),
+            'data2': ('data2-claim-name', False),
         }
         self.assertEqual(kpod.get_persistent_volumes_dict(), expected_dict)
 
@@ -77,10 +77,13 @@ class KubernetesPodVolumeInspectorTestCase(TestCase):
         ]
         kpod = KubernetesPodVolumeInspector(mock_pod)
         kpod.get_persistent_volumes_dict = Mock()
-        kpod.get_persistent_volumes_dict.return_value = {'data1': 'data1-claim', 'data2': 'data2-claim'}
+        kpod.get_persistent_volumes_dict.return_value = {'data1': ('data1-claim', False), 'data2': ('data2-claim', False)}
         mp_volumes = kpod.get_mounted_persistent_volumes()
 
-        self.assertEqual(mp_volumes, [('/data/one', None, 'data1-claim'), ('/data/two', '/basedir', 'data2-claim')])
+        self.assertEqual(mp_volumes, [
+            ('/data/one', None, 'data1-claim', False),
+            ('/data/two', '/basedir', 'data2-claim', False)
+        ])
 
     def test_get_mounted_persistent_volumes_ignores_unmounted_volumes(self):
         mock_pod = Mock()
@@ -97,10 +100,10 @@ class KubernetesPodVolumeInspectorTestCase(TestCase):
         ]
         kpod = KubernetesPodVolumeInspector(mock_pod)
         kpod.get_persistent_volumes_dict = Mock()
-        kpod.get_persistent_volumes_dict.return_value = {'data1': 'data1-claim'}
+        kpod.get_persistent_volumes_dict.return_value = {'data1': ('data1-claim', False)}
         mp_volumes = kpod.get_mounted_persistent_volumes()
 
-        self.assertEqual(mp_volumes, [('/data/one', None, 'data1-claim')])
+        self.assertEqual(mp_volumes, [('/data/one', None, 'data1-claim', False)])
 
 
 class KubernetesVolumeBuilderTestCase(TestCase):
@@ -109,7 +112,7 @@ class KubernetesVolumeBuilderTestCase(TestCase):
         self.volume_builder = KubernetesVolumeBuilder()
 
     def test_finds_persistent_volume(self):
-        self.volume_builder.add_persistent_volume_entry('/prefix/1', None, 'claim1')
+        self.volume_builder.add_persistent_volume_entry('/prefix/1', None, 'claim1', False)
         self.assertIsNotNone(self.volume_builder.find_persistent_volume('/prefix/1f'))
         self.assertIsNone(self.volume_builder.find_persistent_volume('/notfound'))
 
@@ -127,8 +130,8 @@ class KubernetesVolumeBuilderTestCase(TestCase):
 
     def test_add_rw_volume_binding(self):
         self.assertEqual(0, len(self.volume_builder.volumes))
-        self.volume_builder.add_persistent_volume_entry('/prefix/1', None, 'claim1')
-        self.assertEqual({'name':'claim1', 'persistentVolumeClaim': {'claimName': 'claim1'}}, self.volume_builder.volumes[0])
+        self.volume_builder.add_persistent_volume_entry('/prefix/1', None, 'claim1', False)
+        self.assertEqual({'name':'claim1', 'persistentVolumeClaim': {'claimName': 'claim1', 'readOnly': False}}, self.volume_builder.volumes[0])
 
         self.assertEqual(0, len(self.volume_builder.volume_mounts))
         self.volume_builder.add_volume_binding('/prefix/1/input1', '/input1-target', True)
@@ -137,8 +140,8 @@ class KubernetesVolumeBuilderTestCase(TestCase):
     def test_add_ro_volume_binding(self):
         # read-only
         self.assertEqual(0, len(self.volume_builder.volumes))
-        self.volume_builder.add_persistent_volume_entry('/prefix/2', None, 'claim2')
-        self.assertEqual({'name':'claim2', 'persistentVolumeClaim': {'claimName': 'claim2'}}, self.volume_builder.volumes[0])
+        self.volume_builder.add_persistent_volume_entry('/prefix/2', None, 'claim2', True)
+        self.assertEqual({'name':'claim2', 'persistentVolumeClaim': {'claimName': 'claim2', 'readOnly': True}}, self.volume_builder.volumes[0])
 
         self.assertEqual(0, len(self.volume_builder.volume_mounts))
         self.volume_builder.add_volume_binding('/prefix/2/input2', '/input2-target', False)
@@ -169,8 +172,8 @@ class KubernetesVolumeBuilderTestCase(TestCase):
     @patch('calrissian.job.KubernetesPodVolumeInspector')
     def test_add_persistent_volume_entries_from_pod(self, mock_kubernetes_pod_inspector):
         mock_kubernetes_pod_inspector.return_value.get_mounted_persistent_volumes.return_value = [
-            ('/tmp/data1', None, 'data1-claim'),
-            ('/tmp/data2', '/basedir', 'data2-claim'),
+            ('/tmp/data1', None, 'data1-claim', False),
+            ('/tmp/data2', '/basedir', 'data2-claim', False),
         ]
 
         self.volume_builder.add_persistent_volume_entries_from_pod('some-pod-data')
@@ -183,7 +186,8 @@ class KubernetesVolumeBuilderTestCase(TestCase):
             'volume': {
                 'name': 'data1-claim',
                 'persistentVolumeClaim': {
-                    'claimName': 'data1-claim'
+                    'claimName': 'data1-claim',
+                    'readOnly': False
                 }
             }
         }
@@ -193,12 +197,53 @@ class KubernetesVolumeBuilderTestCase(TestCase):
             'volume': {
                 'name': 'data2-claim',
                 'persistentVolumeClaim': {
-                    'claimName': 'data2-claim'
+                    'claimName': 'data2-claim',
+                    'readOnly': False
                 }
             }
         }
         self.assertEqual(pv_entries['/tmp/data1'], expected_entry1)
         self.assertEqual(pv_entries['/tmp/data2'], expected_entry2)
+        volumes = self.volume_builder.volumes
+        self.assertEqual(len(volumes), 2)
+        self.assertEqual(volumes[0], expected_entry1['volume'])
+        self.assertEqual(volumes[1], expected_entry2['volume'])
+
+    @patch('calrissian.job.KubernetesPodVolumeInspector')
+    def test_add_persistent_volume_entries_from_pod_preserves_readonly(self, mock_kubernetes_pod_inspector):
+        mock_kubernetes_pod_inspector.return_value.get_mounted_persistent_volumes.return_value = [
+            ('/tmp/readonly', None, 'readonly-claim', True),
+            ('/tmp/writable', '/basedir', 'writable-claim', False),
+        ]
+
+        self.volume_builder.add_persistent_volume_entries_from_pod('some-pod-data')
+
+        pv_entries = self.volume_builder.persistent_volume_entries
+        self.assertEqual(pv_entries.keys(), set(['/tmp/readonly', '/tmp/writable']))
+        expected_entry1 = {
+            'prefix': '/tmp/readonly',
+            'subPath': None,
+            'volume': {
+                'name': 'readonly-claim',
+                'persistentVolumeClaim': {
+                    'claimName': 'readonly-claim',
+                    'readOnly': True,
+                },
+            }
+        }
+        expected_entry2 = {
+            'prefix': '/tmp/writable',
+            'subPath': '/basedir',
+            'volume': {
+                'name': 'writable-claim',
+                'persistentVolumeClaim': {
+                    'claimName': 'writable-claim',
+                    'readOnly': False,
+                }
+            }
+        }
+        self.assertEqual(pv_entries['/tmp/readonly'], expected_entry1)
+        self.assertEqual(pv_entries['/tmp/writable'], expected_entry2)
         volumes = self.volume_builder.volumes
         self.assertEqual(len(volumes), 2)
         self.assertEqual(volumes[0], expected_entry1['volume'])


### PR DESCRIPTION
Updates KubernetesPodVolumeInspector to check calrissian's claim volumes for read-only, and passes that state down to claim volumes specified for created pods.

Updates the revsort example to mark input data as a read-only claim volume and a read-only volume mount. Tested in OKD on hardspin.

Fixes #79 