### PR TITLE
Adds initContainer to ensure stdout/stderr directories exist

### DIFF
--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -232,9 +232,13 @@ class KubernetesPodBuilder(object):
     # that need to exist.
     def init_containers(self):
         containers = []
+        # get dirname for any actual paths
         dirs_to_create = [os.path.dirname(p) for p in [self.stdout, self.stderr] if p]
-        quoted_dirs_to_create = quoted_arg_list(dirs_to_create)
-        command_list = ['mkdir -p \"{}\";'.format(d) for d in quoted_dirs_to_create]
+        # Remove empty strings
+        dirs_to_create = [d for d in dirs_to_create if d]
+        # Quote if necessary
+        dirs_to_create = quoted_arg_list(dirs_to_create)
+        command_list = ['mkdir -p {};'.format(d) for d in dirs_to_create]
         if command_list:
             containers.append({
                 'name': self.init_container_name(),

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch, call, create_autospec
 from calrissian.job import k8s_safe_name, KubernetesVolumeBuilder, VolumeBuilderException, KubernetesPodBuilder, random_tag, read_yaml
-from calrissian.job import CalrissianCommandLineJob, KubernetesPodVolumeInspector, CalrissianCommandLineJobException, total_size
+from calrissian.job import CalrissianCommandLineJob, KubernetesPodVolumeInspector, CalrissianCommandLineJobException, total_size, quoted_arg_list
 from cwltool.errors import UnsupportedRequirement
 from calrissian.context import CalrissianRuntimeContext
 from calrissian.k8s import CompletionResult
@@ -39,6 +39,13 @@ class ReadYamlTestCase(TestCase):
         self.assertEqual(result, mock_result)
         self.assertEqual(mock_open.call_args, call('filename.yaml'))
         self.assertEqual(mock_yaml.safe_load.call_args, call(mock_open.return_value.__enter__.return_value))
+
+
+class QuotedArgListTestCase(TestCase):
+
+    def test_quoted_arg_list(self):
+        arg_list = ['ls', '@foo']
+        self.assertEqual(quoted_arg_list(arg_list), ['ls', '\'@foo\''])
 
 
 class KubernetesPodVolumeInspectorTestCase(TestCase):
@@ -336,6 +343,33 @@ class KubernetesPodBuilderTestCase(TestCase):
         self.pod_builder.labels = {'key1': 123}
         self.assertEqual(self.pod_builder.pod_labels(), {'key1':'123'})
 
+    def test_init_containers_empty_when_no_stdout_or_stderr(self):
+        self.pod_builder.stdout = None
+        self.pod_builder.stderr = None
+        self.assertEqual(len(self.pod_builder.init_containers()), 0)
+
+    def test_init_containers_empty_when_stdout_is_local_file(self):
+        self.pod_builder.stdout = 'stdout.txt'
+        self.pod_builder.stderr = None
+        self.assertEqual(len(self.pod_builder.init_containers()), 0)
+
+    def test_init_containers_empty_when_stderr_is_local_file(self):
+        self.pod_builder.stdout = None
+        self.pod_builder.stderr = 'stderr.txt'
+        self.assertEqual(len(self.pod_builder.init_containers()), 0)
+
+    def test_init_containers_when_stdout_has_path(self):
+        self.pod_builder.stdout = 'out/to/stdout.txt'
+        self.pod_builder.stderr = 'err/to/stderr.txt'
+        self.pod_builder.init_container_image = 'init-image:2.0'
+        init_containers = self.pod_builder.init_containers()
+        self.assertEqual(len(init_containers), 1)
+        container = init_containers[0]
+        self.assertEqual(container['name'], 'podname-init')
+        self.assertEqual(container['image'], 'init-image:2.0')
+        self.assertEqual(container['command'], ['/bin/sh','-c','mkdir -p out/to; mkdir -p err/to;'])
+        self.assertEqual(container['volumeMounts'], self.pod_builder.volume_mounts)
+
     @patch('calrissian.job.random_tag')
     def test_build(self, mock_random_tag):
         mock_random_tag.return_value = 'random'
@@ -350,6 +384,7 @@ class KubernetesPodBuilderTestCase(TestCase):
             'apiVersion': 'v1',
             'kind':'Pod',
             'spec': {
+                'initContainers': [],
                 'containers': [
                     {
                         'name': 'podname-container',
@@ -646,10 +681,12 @@ class CalrissianCommandLineJobTestCase(TestCase):
         # and can be tested later
         pass
 
-    def test_quoted_command_line(self, mock_volume_builder, mock_client):
+    @patch('calrissian.job.quoted_arg_list')
+    def test_quoted_command_line(self, mock_quoted_arg_list, mock_volume_builder, mock_client):
         job = self.make_job()
-        job.command_line = ['ls', '@foo']
-        self.assertEqual(job.quoted_command_line(), ['ls', '\'@foo\''])
+        result = job.quoted_command_line()
+        self.assertEqual(mock_quoted_arg_list.return_value, result)
+        self.assertEqual(mock_quoted_arg_list.call_args, call(job.command_line))
 
     def test_run(self, mock_volume_builder, mock_client):
         job = self.make_job()


### PR DESCRIPTION
- Checks if `job.stdout` or `job.stderr` are paths within directories
- Adds an `initContainer` to the Pod spec if these are directories, and creates them before attempting redirection inside the primary `container`

for #8 