### PR TITLE
Upgrade to latest stable kubernetes library release (10.0.1)

### DIFF
--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -89,7 +89,7 @@ class KubernetesClient(object):
 
     def delete_pod_name(self, pod_name):
         try:
-            self.core_api_instance.delete_namespaced_pod(pod_name, self.namespace, client.V1DeleteOptions())
+            self.core_api_instance.delete_namespaced_pod(pod_name, self.namespace)
         except client.rest.ApiException as e:
             raise CalrissianJobException('Error deleting pod named {}'.format(pod_name), e)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ google-auth==1.6.3
 humanfriendly==4.18
 idna==2.8
 isodate==0.6.0
-kubernetes==8.0.1
+kubernetes==10.0.1
 lockfile==0.12.2
 lxml==4.4.0
 mistune==0.8.4

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     description='CWL runner for Kubernetes',
     install_requires=[
         'urllib3<1.25,>=1.24.2',
-        'kubernetes==8.0.1',
+        'kubernetes==10.0.1',
         'cwltool==1.0.20190621234233',
     ],
     test_suite='nose2.collector.collector',

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -39,7 +39,7 @@ class LoadConfigTestCase(TestCase):
         self.assertTrue(mock_config.load_kube_config.called)
 
 
-@patch('calrissian.k8s.client')
+@patch('calrissian.k8s.client', autospec=True)
 @patch('calrissian.k8s.load_config_get_namespace')
 class KubernetesClientTestCase(TestCase):
 


### PR DESCRIPTION
Upgrades to use the latest k8s python library.
This doesn't seem to noticeably help with GKE reliability issue #96. 
May help with issue following logs #60.
