### PR TITLE
Fix error when PodMonitor cleanup is called before remove

### DIFF
--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -263,9 +263,12 @@ class PodMonitor(object):
         PodMonitor.pod_names.append(pod.metadata.name)
 
     def remove(self, pod):
-        log.info('PodMonitor removing {}'.format(pod.metadata.name))
         # This has to look up the pod by something unique
-        PodMonitor.pod_names.remove(pod.metadata.name)
+        if pod.metadata.name in PodMonitor.pod_names:
+            log.info('PodMonitor removing {}'.format(pod.metadata.name))
+            PodMonitor.pod_names.remove(pod.metadata.name)
+        else:
+            log.warning('PodMonitor {} has already been removed'.format(pod.metadata.name))
 
     @staticmethod
     def cleanup():

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -366,7 +366,8 @@ class PodMonitorTestCase(TestCase):
         self.assertTrue(mock_pod_monitor.cleanup.called)
 
     @patch('calrissian.k8s.KubernetesClient')
-    def test_remove_after_cleanup(self, mock_client):
+    @patch('calrissian.k8s.log')
+    def test_remove_after_cleanup(self, mock_log, mock_client):
         # Depending upon timing cleanup may get called before we receive a remove pod event
         pod = self.make_mock_pod('pod-123')
         with PodMonitor() as monitor:
@@ -374,6 +375,11 @@ class PodMonitorTestCase(TestCase):
         PodMonitor.cleanup()
         with PodMonitor() as monitor:
             monitor.remove(pod)
+        mock_log.info.assert_has_calls([
+            call('PodMonitor adding pod-123'),
+            call('PodMonitor deleting pod pod-123'),
+        ])
+        mock_log.warning.assert_called_with('PodMonitor pod-123 has already been removed')
 
 
 class CompletionResultTestCase(TestCase):

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -365,6 +365,16 @@ class PodMonitorTestCase(TestCase):
         delete_pods()
         self.assertTrue(mock_pod_monitor.cleanup.called)
 
+    @patch('calrissian.k8s.KubernetesClient')
+    def test_remove_after_cleanup(self, mock_client):
+        # Depending upon timing cleanup may get called before we receive a remove pod event
+        pod = self.make_mock_pod('pod-123')
+        with PodMonitor() as monitor:
+            monitor.add(pod)
+        PodMonitor.cleanup()
+        with PodMonitor() as monitor:
+            monitor.remove(pod)
+
 
 class CompletionResultTestCase(TestCase):
 


### PR DESCRIPTION
When an exception is raised in [cwlmain delete_pods/PodMonitor.cleanup will be called](https://github.com/Duke-GCB/calrissian/blob/3de52f853539d117ca2d2da423dcdd3858248d2a/calrissian/main.py#L118-L127). This removes all pods from PodMonitor's list. If there are active pods being monitored in other threads, when the pods exit podMonitor.remove will be run this results in `ValueError: list.remove(x): x not in list`. 

The change here handles this case by checking to see if the pod is still in the list before trying to remove it.

More details:  https://github.com/Duke-GCB/calrissian/issues/96#issuecomment-523453031.

_With refactoring changes coming up we may want to not merge this._


