### PR TITLE
Implements simple k8s API retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,22 @@ To view open issues related to conformance, see the [conformance](https://github
 ## Setup
 
 Please see [examples](examples) for installation and setup instructions.
+
+## Environment Variables
+
+Calrissian's behaviors can be customized by setting the following environment variables in the container specification.
+
+### Pod lifecycle
+
+By default, pods for a job step will be deleted after termination
+
+- `CALRISSIAN_DELETE_PODS`: Default `true`. If `false`, job step pods will not be deleted.
+
+### Kubernetes API retries
+
+When encountering a Kubernetes API exception, Calrissian uses a library to retry API calls with an exponential backoff. See the [tenacity documentation](https://tenacity.readthedocs.io/en/latest/index.html#waiting-before-retrying) for details.
+
+- `RETRY_MULTIPLIER`: Default `5`. Unit for multiplying the exponent interval.
+- `RETRY_MIN`: Default `5`. Minimum interval between retries.
+- `RETRY_MAX`: Default `1200`. Maximum interval between retries.
+- `RETRY_ATTEMPTS`: Default `10`. Max number of retries before giving up.

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -1,6 +1,7 @@
 from kubernetes import client, config, watch
 from kubernetes.client.api_client import ApiException
 from kubernetes.config.config_exception import ConfigException
+from calrissian.retry import retry_exponential_if_exception_type
 import threading
 import logging
 import os
@@ -70,6 +71,7 @@ class KubernetesClient(object):
         self.namespace = load_config_get_namespace()
         self.core_api_instance = client.CoreV1Api()
 
+    @retry_exponential_if_exception_type(ApiException, log)
     def submit_pod(self, pod_body):
         with PodMonitor() as monitor:
             pod = self.core_api_instance.create_namespaced_pod(self.namespace, pod_body)
@@ -89,6 +91,7 @@ class KubernetesClient(object):
         else:
             return True
 
+    @retry_exponential_if_exception_type(ApiException, log)
     def delete_pod_name(self, pod_name):
         try:
             self.core_api_instance.delete_namespaced_pod(pod_name, self.namespace)
@@ -117,6 +120,7 @@ class KubernetesClient(object):
         )
         log.info('handling completion with {}'.format(exit_code))
 
+    @retry_exponential_if_exception_type(ApiException, log)
     def follow_logs(self):
         pod_name = self.pod.metadata.name
         log.info('[{}] follow_logs start'.format(pod_name))
@@ -131,6 +135,7 @@ class KubernetesClient(object):
             log.debug('[{}] {}'.format(pod_name, line))
         log.info('[{}] follow_logs end'.format(pod_name))
 
+    @retry_exponential_if_exception_type(ApiException, log)
     def wait_for_completion(self):
         w = watch.Watch()
         for event in w.stream(self.core_api_instance.list_namespaced_pod, self.namespace, field_selector=self._get_pod_field_selector()):
@@ -212,6 +217,7 @@ class KubernetesClient(object):
         """
         return (state.terminated.started_at, state.terminated.finished_at,)
 
+    @retry_exponential_if_exception_type(ApiException, log)
     def get_pod_for_name(self, pod_name):
         """
         Given a pod name return details about this pod

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -5,6 +5,7 @@ from calrissian.retry import retry_exponential_if_exception_type
 import threading
 import logging
 import os
+from urllib3.exceptions import HTTPError
 
 log = logging.getLogger('calrissian.k8s')
 
@@ -71,7 +72,7 @@ class KubernetesClient(object):
         self.namespace = load_config_get_namespace()
         self.core_api_instance = client.CoreV1Api()
 
-    @retry_exponential_if_exception_type(ApiException, log)
+    @retry_exponential_if_exception_type((ApiException, HTTPError,), log)
     def submit_pod(self, pod_body):
         with PodMonitor() as monitor:
             pod = self.core_api_instance.create_namespaced_pod(self.namespace, pod_body)
@@ -91,7 +92,7 @@ class KubernetesClient(object):
         else:
             return True
 
-    @retry_exponential_if_exception_type(ApiException, log)
+    @retry_exponential_if_exception_type((ApiException, HTTPError,), log)
     def delete_pod_name(self, pod_name):
         try:
             self.core_api_instance.delete_namespaced_pod(pod_name, self.namespace)
@@ -120,7 +121,7 @@ class KubernetesClient(object):
         )
         log.info('handling completion with {}'.format(exit_code))
 
-    @retry_exponential_if_exception_type(ApiException, log)
+    @retry_exponential_if_exception_type((ApiException, HTTPError,), log)
     def follow_logs(self):
         pod_name = self.pod.metadata.name
         log.info('[{}] follow_logs start'.format(pod_name))
@@ -135,7 +136,7 @@ class KubernetesClient(object):
             log.debug('[{}] {}'.format(pod_name, line))
         log.info('[{}] follow_logs end'.format(pod_name))
 
-    @retry_exponential_if_exception_type(ApiException, log)
+    @retry_exponential_if_exception_type((ApiException, HTTPError,), log)
     def wait_for_completion(self):
         w = watch.Watch()
         for event in w.stream(self.core_api_instance.list_namespaced_pod, self.namespace, field_selector=self._get_pod_field_selector()):
@@ -217,7 +218,7 @@ class KubernetesClient(object):
         """
         return (state.terminated.started_at, state.terminated.finished_at,)
 
-    @retry_exponential_if_exception_type(ApiException, log)
+    @retry_exponential_if_exception_type((ApiException, HTTPError,), log)
     def get_pod_for_name(self, pod_name):
         """
         Given a pod name return details about this pod
@@ -280,6 +281,7 @@ class PodMonitor(object):
 
     @staticmethod
     def cleanup():
+        log.info('Starting Cleanup')
         with PodMonitor() as monitor:
             k8s_client = KubernetesClient()
             for pod_name in PodMonitor.pod_names:
@@ -289,6 +291,7 @@ class PodMonitor(object):
                 except Exception:
                     log.error('Error deleting pod named {}, ignoring'.format(pod_name))
             PodMonitor.pod_names = []
+        log.info('Finishing Cleanup')
 
 
 def delete_pods():

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -97,7 +97,12 @@ class KubernetesClient(object):
         try:
             self.core_api_instance.delete_namespaced_pod(pod_name, self.namespace)
         except ApiException as e:
-            raise CalrissianJobException('Error deleting pod named {}'.format(pod_name), e)
+            if e.status == 404:
+                # pod was not found - already deleted, so do not retry
+                pass
+            else:
+                # Re-raise
+                raise
 
     def _handle_completion(self, state, container):
         """

--- a/calrissian/retry.py
+++ b/calrissian/retry.py
@@ -1,11 +1,15 @@
-from tenacity import retry, wait, wait_exponential, retry_if_exception_type
+from tenacity import retry, wait, wait_exponential, retry_if_exception_type, stop_after_attempt, before_sleep_log
+import logging
 import os
-import functools
+
+
+logger = logging.getLogger('calrissian.retry')
 
 class WaitRetry(object):
-    MULTIPLIER = int(os.getenv('WAIT_RETRY_MULTIPLIER', 1))
-    MIN = int(os.getenv('WAIT_RETRY_MIN', 4))
-    MAX = int(os.getenv('WAIT_RETRY_MAX', 10))
+    MULTIPLIER = int(os.getenv('WAIT_RETRY_MULTIPLIER', 1)) # time unit for waiting between retries, e.g. 1 second
+    MIN = int(os.getenv('WAIT_RETRY_MIN', 10)) # starting interval for retrying
+    MAX = int(os.getenv('WAIT_RETRY_MAX', 60)) # max interval between retries
+    STOP = int(os.getenv('WAIT_ATTEMPTS', 3)) # Max number of retries before giving up
 
 
 # types can be a tuple
@@ -13,7 +17,9 @@ def retry_exponential_if_exception_type(exc_class):
     def decorator_retry(func):
         @retry(
             retry=retry_if_exception_type(exc_class),
-            wait=wait_exponential(multiplier=WaitRetry.MULTIPLIER, min=WaitRetry.MIN, max=WaitRetry.MAX)
+            wait=wait_exponential(multiplier=WaitRetry.MULTIPLIER, min=WaitRetry.MIN, max=WaitRetry.MAX),
+            stop=stop_after_attempt(WaitRetry.STOP),
+            before_sleep=before_sleep_log(logger, logging.DEBUG)
         )
         def wrapper(*args, **kwargs):
             func(*args, **kwargs)

--- a/calrissian/retry.py
+++ b/calrissian/retry.py
@@ -1,4 +1,4 @@
-from tenacity import retry, wait, wait_exponential, retry_if_exception_type, stop_after_attempt, after_log
+from tenacity import retry, wait, wait_exponential, retry_if_exception_type, stop_after_attempt, before_sleep_log
 import logging
 import os
 
@@ -20,7 +20,7 @@ def retry_exponential_if_exception_type(exc_class):
             retry=retry_if_exception_type(exc_class),
             wait=wait_exponential(multiplier=RetryParameters.MULTIPLIER, min=RetryParameters.MIN, max=RetryParameters.MAX),
             stop=stop_after_attempt(RetryParameters.ATTEMPTS),
-            after=after_log(logger, logging.DEBUG),
+            before_sleep=before_sleep_log(logger, logging.DEBUG),
             reraise=True
         )
         def wrapper(*args, **kwargs):

--- a/calrissian/retry.py
+++ b/calrissian/retry.py
@@ -1,0 +1,21 @@
+from tenacity import retry, wait, wait_exponential, retry_unless_exception_type
+import os
+import functools
+
+class WaitRetry(object):
+    MULTIPLIER = int(os.getenv('WAIT_RETRY_MULTIPLIER', 1))
+    MIN = int(os.getenv('WAIT_RETRY_MIN', 4))
+    MAX = int(os.getenv('WAIT_RETRY_MAX', 10))
+
+
+def retry_exponential_unless_exception_type(exc_class):
+    def decorator_retry(func):
+        @retry(
+            retry=retry_unless_exception_type(exc_class),
+            wait=wait_exponential(multiplier=WaitRetry.MULTIPLIER, min=WaitRetry.MIN, max=WaitRetry.MAX)
+        )
+        def wrapper(*args, **kwargs):
+            func(*args, **kwargs)
+        return wrapper
+    return decorator_retry
+

--- a/calrissian/retry.py
+++ b/calrissian/retry.py
@@ -4,9 +4,9 @@ import os
 
 
 class RetryParameters(object):
-    MULTIPLIER = int(os.getenv('RETRY_MULTIPLIER', 5)) #  Unit for multiplying the exponent
-    MIN = int(os.getenv('RETRY_MIN', 5)) # Min time for retrying
-    MAX = int(os.getenv('RETRY_MAX', 1200)) # Max interval between retries
+    MULTIPLIER = float(os.getenv('RETRY_MULTIPLIER', 5)) #  Unit for multiplying the exponent
+    MIN = float(os.getenv('RETRY_MIN', 5)) # Min time for retrying
+    MAX = float(os.getenv('RETRY_MAX', 1200)) # Max interval between retries
     ATTEMPTS = int(os.getenv('RETRY_ATTEMPTS', 10)) # Max number of retries before giving up
 
 

--- a/calrissian/retry.py
+++ b/calrissian/retry.py
@@ -1,4 +1,4 @@
-from tenacity import retry, wait, wait_exponential, retry_unless_exception_type
+from tenacity import retry, wait, wait_exponential, retry_if_exception_type
 import os
 import functools
 
@@ -8,10 +8,11 @@ class WaitRetry(object):
     MAX = int(os.getenv('WAIT_RETRY_MAX', 10))
 
 
-def retry_exponential_unless_exception_type(exc_class):
+# types can be a tuple
+def retry_exponential_if_exception_type(exc_class):
     def decorator_retry(func):
         @retry(
-            retry=retry_unless_exception_type(exc_class),
+            retry=retry_if_exception_type(exc_class),
             wait=wait_exponential(multiplier=WaitRetry.MULTIPLIER, min=WaitRetry.MIN, max=WaitRetry.MAX)
         )
         def wrapper(*args, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ scandir==1.10.0
 schema-salad==4.5.20190621200723
 shellescape==3.4.1
 six==1.12.0
+tenacity==5.1.1
 typing-extensions==3.7.4
 urllib3==1.24.3
 websocket-client==0.56.0

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'urllib3<1.25,>=1.24.2',
         'kubernetes==10.0.1',
         'cwltool==1.0.20190621234233',
+        'tenacity==5.1.1',
     ],
     test_suite='nose2.collector.collector',
     tests_require=['nose2'],

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -370,7 +370,9 @@ class PodMonitorTestCase(TestCase):
             monitor.remove(pod)
         mock_log.info.assert_has_calls([
             call('PodMonitor adding pod-123'),
+            call('Starting Cleanup'),
             call('PodMonitor deleting pod pod-123'),
+            call('Finishing Cleanup'),
         ])
         mock_log.warning.assert_called_with('PodMonitor pod-123 has already been removed')
 

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -245,12 +245,11 @@ class KubernetesClientTestCase(TestCase):
         kc.delete_pod_name('pod-123')
         self.assertEqual('pod-123', mock_client.CoreV1Api.return_value.delete_namespaced_pod.call_args[0][0])
 
-    def test_delete_pod_name_raises(self, mock_get_namespace, mock_client):
-        mock_client.rest.ApiException = Exception
-        mock_client.CoreV1Api.return_value.delete_namespaced_pod.side_effect = ApiException
+    def test_delete_pod_name_ignores_404(self, mock_get_namespace, mock_client):
+        mock_client.CoreV1Api.return_value.delete_namespaced_pod.side_effect = ApiException(status=404)
         kc = KubernetesClient()
-        with self.assertRaisesRegex(CalrissianJobException, 'Error deleting pod named pod-123'):
-            kc.delete_pod_name('pod-123')
+        kc.delete_pod_name('pod-123')
+        self.assertEqual('pod-123', mock_client.CoreV1Api.return_value.delete_namespaced_pod.call_args[0][0])
 
     @patch('calrissian.k8s.log')
     def test_follow_logs_streams_to_logging(self, mock_log, mock_get_namespace, mock_client):

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,72 @@
+from calrissian.retry import retry_exponential_if_exception_type
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+
+class RetryTestCase(TestCase):
+    def setUp(self):
+        self.logger = Mock()
+        self.mock = Mock()
+
+    def setup_mock_retry_parameters(self, mock_retry_parameters):
+        mock_retry_parameters.MULTIPLIER = 0.001
+        mock_retry_parameters.MIN = 0.001
+        mock_retry_parameters.MAX = 0.010
+        mock_retry_parameters.ATTEMPTS = 5
+
+    def test_retry_calls_wrapped_function(self):
+        @retry_exponential_if_exception_type(ValueError, self.logger)
+        def func():
+            return self.mock()
+
+        result = func()
+        self.assertEqual(result, self.mock.return_value)
+        self.assertEqual(self.mock.call_count, 1)
+
+    @patch('calrissian.retry.RetryParameters')
+    def test_retry_gives_up_and_raises(self, mock_retry_parameters):
+        self.setup_mock_retry_parameters(mock_retry_parameters)
+        self.mock.side_effect = ValueError('value error')
+
+        @retry_exponential_if_exception_type(ValueError, self.logger)
+        def func():
+            self.mock()
+
+        with self.assertRaisesRegex(ValueError, 'value error'):
+            func()
+
+        self.assertEqual(self.mock.call_count, 5)
+
+    @patch('calrissian.retry.RetryParameters')
+    def test_retry_eventually_succeeds_without_exception(self, mock_retry_parameters):
+        self.setup_mock_retry_parameters(mock_retry_parameters)
+
+        @retry_exponential_if_exception_type(ValueError, self.logger)
+        def func():
+            r = self.mock()
+            if self.mock.call_count < 3:
+                raise ValueError('value error')
+            return r
+
+        result = func()
+
+        self.assertEqual(result, self.mock.return_value)
+        self.assertEqual(self.mock.call_count, 3)
+
+    @patch('calrissian.retry.RetryParameters')
+    def test_retry_raises_other_exceptions_without_second_attempt(self, mock_retry_parameters):
+        self.setup_mock_retry_parameters(mock_retry_parameters)
+
+        class ExceptionA(Exception): pass
+        class ExceptionB(Exception): pass
+
+        self.mock.side_effect = ExceptionA('exception a')
+
+        @retry_exponential_if_exception_type(ExceptionB, self.logger)
+        def func():
+            self.mock()
+
+        with self.assertRaisesRegex(ExceptionA, 'exception a'):
+            func()
+
+        self.assertEqual(self.mock.call_count, 1)


### PR DESCRIPTION
Uses tenacity to retry API calls that may fail due to temporary unavailable k8s API

This work was intended to tolerate automated GKE cluster master upgrades (during which the API server is unavailable). While it addresses that and continues the workflow after the API server returns, the upgrade/autoscaling was causing nodes to delete running pods and terminate them prematurely.

In the interest of seeing a large workflow run, we'll not use auto-scaling on GKE for now, and revisit this later if necessary.

Fixes the `APIException`s, and `ConnectionError`s related to #96. The `Error Collecting Output` issues were occurring in my testing when a GKE node was killed and terminated pods running on it.