### PR TITLE
cwltool bumped to 3.1

### DIFF
--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -1,3 +1,4 @@
+from typing import Dict
 from cwltool.job import ContainerCommandLineJob, needs_shell_quoting_re
 from cwltool.utils import DEFAULT_TMP_PREFIX
 from cwltool.errors import WorkflowException, UnsupportedRequirement
@@ -590,6 +591,15 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
                     log.debug('shutil.copytree({}, {})'.format(volume.resolved, host_outdir_tgt))
                     shutil.copytree(volume.resolved, host_outdir_tgt)
                 ensure_writable(host_outdir_tgt or new_dir)
+
+    def _required_env(self) -> Dict[str, str]:
+        # spec currently says "HOME must be set to the designated output
+        # directory." but spec might change to designated temp directory.
+        # runtime.append("--env=HOME=/tmp")
+        return {
+            "TMPDIR": self.CONTAINER_TMPDIR,
+            "HOME": self.builder.outdir,
+        }
 
     def run(self, runtimeContext, tmpdir_lock=None):
         self.check_requirements()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ chardet==3.0.4
 coloredlogs==10.0
 coverage==4.5.4
 cryptography==3.3.2
-cwltool==3.0.20210124104916
+cwltool==3.1.20211004060744
 decorator==4.4.0
 freezegun==0.3.12
 future==0.17.1
@@ -41,7 +41,7 @@ requests-oauthlib==1.2.0
 rsa==4.1
 ruamel.yaml>=0.12.4,<=0.16.5
 scandir==1.10.0
-schema-salad>=7.0.20210124093443,<8
+schema-salad>=8.2.20210914115719,<9
 shellescape>=3.4.1,<3.5
 six==1.12.0
 tenacity==5.1.1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'urllib3<1.25,>=1.24.2',
         'kubernetes==10.0.1',
-        'cwltool==3.0.20210124104916',
+        'cwltool==3.1.20211004060744',
         'tenacity==5.1.1',
     ],
     test_suite='nose2.collector.collector',


### PR DESCRIPTION
**Proposed Changes:**

***Upgrade cwltool to v3***
This PR upgrades cwltool base tool to v3 3.1.20211004060744. This version does not change fundamentally the way calrissian executes workflows but ensures a compatibility for CWL application developed and tested with cwltool to be properly ported to K8s with calrissian

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] I have added my changes to a [CHANGELOG](https://github.com/Terradue/calrissian/blob/feature/cwl3/CHANGELOG.md).
