### PR TITLE
Apply `--no-match-user` arg from cwltool to k8s

### DIFF
--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -187,7 +187,7 @@ class KubernetesVolumeBuilder(object):
 
 class KubernetesPodBuilder(object):
 
-    def __init__(self, name, container_image, environment, volume_mounts, volumes, command_line, stdout, stderr, stdin, resources, labels):
+    def __init__(self, name, container_image, environment, volume_mounts, volumes, command_line, stdout, stderr, stdin, resources, labels, security_context):
         self.name = name
         self.container_image = container_image
         self.environment = environment
@@ -199,6 +199,7 @@ class KubernetesPodBuilder(object):
         self.stdin = stdin
         self.resources = resources
         self.labels = labels
+        self.security_context = security_context
 
     def pod_name(self):
         tag = random_tag()
@@ -336,11 +337,7 @@ class KubernetesPodBuilder(object):
                     ],
                     'restartPolicy': 'Never',
                     'volumes': self.volumes,
-                    'securityContext': {
-                        'runAsUser': 1000,
-                        'runAsGroup': 3000,
-                        'fsGroup': 2000,
-                    }
+                    'securityContext': self.security_context
             }
         }
 
@@ -451,6 +448,15 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
         else:
             return {}
 
+    def get_security_context(self, runtimeContext):
+        if not runtimeContext.no_match_user:
+            return {
+                'runAsUser': os.getuid(),
+                'runAsGroup': os.getgid()
+            }
+        else:
+            return {}
+
     def get_pod_env_vars(self, runtimeContext):
         if runtimeContext.pod_env_vars:
             return read_yaml(runtimeContext.pod_env_vars)
@@ -490,8 +496,6 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
                 secret_store=runtimeContext.secret_store,
                 any_path_okay=any_path_okay)
 
-        pod_labels = self.get_pod_labels(runtimeContext)
-
         k8s_builder = KubernetesPodBuilder(
             self.name,
             self._get_container_image(),
@@ -503,7 +507,8 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
             self.stderr,
             self.stdin,
             self.builder.resources,
-            pod_labels,
+            self.get_pod_labels(runtimeContext),
+            self.get_security_context(runtimeContext),
         )
         built = k8s_builder.build()
         log.debug('{}\n{}{}\n'.format('-' * 80, yaml.dump(built), '-' * 80))

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -43,7 +43,6 @@ def add_arguments(parser):
     parser.add_argument('--stdout', type=Text, nargs='?', help='Output file name to tee standard output (CWL output object)')
     parser.add_argument('--stderr', type=Text, nargs='?', help='Output file name to tee standard error to (includes tool logs)')
 
-
 def print_version():
     print(version())
 

--- a/examples/CalrissianJob-fail-wf.yaml
+++ b/examples/CalrissianJob-fail-wf.yaml
@@ -8,6 +8,9 @@ spec:
       containers:
       - name: calrissian
         image: dukegcb/calrissian:latest
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["calrissian"]
         args:
           - "--max-ram"

--- a/examples/CalrissianJob-revsort-single-default-container.yaml
+++ b/examples/CalrissianJob-revsort-single-default-container.yaml
@@ -9,6 +9,9 @@ spec:
       containers:
       - name: calrissian
         image: dukegcb/calrissian:latest
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["calrissian"]
         args:
           - "--default-container"

--- a/examples/CalrissianJob-revsort-single.yaml
+++ b/examples/CalrissianJob-revsort-single.yaml
@@ -9,6 +9,9 @@ spec:
       containers:
       - name: calrissian
         image: dukegcb/calrissian:latest
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["calrissian"]
         args:
           - "--max-ram"

--- a/examples/CalrissianJob-revsort.yaml
+++ b/examples/CalrissianJob-revsort.yaml
@@ -9,6 +9,9 @@ spec:
       containers:
       - name: calrissian
         image: dukegcb/calrissian:latest
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command: ["calrissian"]
         args:
           - "--stdout"

--- a/examples/StageInputDataJob.yaml
+++ b/examples/StageInputDataJob.yaml
@@ -8,6 +8,9 @@ spec:
       containers:
       - name: stage-input-data
         image: dukegcb/calrissian:latest
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command:
         - "sh"
         - "-c"

--- a/examples/ViewResultsJob.yaml
+++ b/examples/ViewResultsJob.yaml
@@ -8,6 +8,9 @@ spec:
       containers:
       - name: view-results
         image: dukegcb/calrissian:latest
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         command:
         - "sh"
         - "-c"

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase
 from unittest.mock import Mock, patch, call, create_autospec
 from calrissian.job import k8s_safe_name, KubernetesVolumeBuilder, VolumeBuilderException, KubernetesPodBuilder, random_tag, read_yaml
@@ -283,9 +284,10 @@ class KubernetesPodBuilderTestCase(TestCase):
         self.stdin = 'stdin.txt'
         self.resources = {'cores': 1, 'ram': 1024}
         self.labels = {'key1': 'val1', 'key2': 123}
+        self.security_context = { 'runAsUser': os.getuid(),'runAsGroup': os.getgid() }
         self.pod_builder = KubernetesPodBuilder(self.name, self.container_image, self.environment, self.volume_mounts,
                                                 self.volumes, self.command_line, self.stdout, self.stderr, self.stdin,
-                                                self.resources, self.labels)
+                                                self.resources, self.labels, self.security_context)
 
     @patch('calrissian.job.random_tag')
     def test_safe_pod_name(self, mock_random_tag):
@@ -419,9 +421,8 @@ class KubernetesPodBuilderTestCase(TestCase):
                 'restartPolicy': 'Never',
                 'volumes': self.volumes,
                 'securityContext': {
-                    'runAsUser': 1000,
-                    'runAsGroup': 3000,
-                    'fsGroup': 2000,
+                    'runAsUser': os.getuid(),
+                    'runAsGroup': os.getgid()
                 }
             }
         }
@@ -623,6 +624,7 @@ class CalrissianCommandLineJobTestCase(TestCase):
             job.stdin,
             job.builder.resources,
             mock_read_yaml.return_value,
+            job.get_security_context(mock_runtime_context)
         ))
         # calls builder.build
         # returns that
@@ -754,6 +756,19 @@ class CalrissianCommandLineJobTestCase(TestCase):
             call.exit(None, None, None)
             ]
         self.assertEqual(expected_calls, manager.mock_calls)
+
+    def test_get_security_context(self, mock_volume_builder, mock_client):
+        mock_runtime_context = Mock(no_match_user=False)
+        expected_security_context = { 'runAsUser': os.getuid(), 'runAsGroup': os.getgid() }
+        job = self.make_job()
+        security_context = job.get_security_context(mock_runtime_context)
+        self.assertEqual(security_context, expected_security_context)
+    
+    def test_get_security_context_empty(self, mock_volume_builder, mock_client):
+        mock_runtime_context = Mock(no_match_user=True)
+        job = self.make_job()
+        security_context = job.get_security_context(mock_runtime_context)
+        self.assertEqual(security_context, {})
 
     @patch('calrissian.job.read_yaml')
     def test_get_pod_labels(self, mock_read_yaml, mock_volume_builder, mock_client):


### PR DESCRIPTION
## Related issues: #110 

## Proposed Changes:

### Apply `--no-match-user` arg from cwltool to k8s

This PR updates calrissian to take into account the `--no-match-user` argument of cwltool.
Practically, by default, a [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) is applied to pods with the same `uid` and `gid` of the calrissian job that can be set itself via the `securityContext` of the Job spec.
if `--no-match-user` is set, the `securityContext` of the pods are left empty.

## PR Checklist:

- [X] I have added my changes to a [CHANGELOG](https://github.com/Terradue/calrissian/blob/feature/cwl3/CHANGELOG.md).
