### PR TITLE
Feature/nodeSelector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ calrissian/__pycache__/
 calrissian.egg-info/
 tests/__pycache__/
 .vscode
+env37

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+adds an argument --pod-nodeselectors <yaml_file> to add a node selector for computing pods
+
 ### Changed
 
 - cwltool upgraded to current version 3.1 + all requirements

--- a/calrissian/context.py
+++ b/calrissian/context.py
@@ -19,4 +19,5 @@ class CalrissianRuntimeContext(RuntimeContext):
         # None and let super() handle the rest.
         self.pod_labels = None
         self.pod_env_vars = None
+        self.pod_nodeselectors = None
         return super(CalrissianRuntimeContext, self).__init__(kwargs)

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -39,6 +39,7 @@ def add_arguments(parser):
     parser.add_argument('--max-cores', type=str, help='Maximum number of CPU cores to use')
     parser.add_argument('--pod-labels', type=Text, nargs='?', help='YAML file of labels to add to Pods submitted')
     parser.add_argument('--pod-env-vars', type=Text, nargs='?', help='YAML file of environment variables to add at runtime to Pods submitted')
+    parser.add_argument('--pod-node-selectors', type=Text, nargs='?', help='YAML file of node selectors to add to Pods submitted')
     parser.add_argument('--usage-report', type=Text, nargs='?', help='Output JSON file name to record resource usage')
     parser.add_argument('--stdout', type=Text, nargs='?', help='Output file name to tee standard output (CWL output object)')
     parser.add_argument('--stderr', type=Text, nargs='?', help='Output file name to tee standard error to (includes tool logs)')

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -39,7 +39,7 @@ def add_arguments(parser):
     parser.add_argument('--max-cores', type=str, help='Maximum number of CPU cores to use')
     parser.add_argument('--pod-labels', type=Text, nargs='?', help='YAML file of labels to add to Pods submitted')
     parser.add_argument('--pod-env-vars', type=Text, nargs='?', help='YAML file of environment variables to add at runtime to Pods submitted')
-    parser.add_argument('--pod-node-selectors', type=Text, nargs='?', help='YAML file of node selectors to add to Pods submitted')
+    parser.add_argument('--pod-nodeselectors', type=Text, nargs='?', help='YAML file of node selectors to add to Pods submitted')
     parser.add_argument('--usage-report', type=Text, nargs='?', help='Output JSON file name to record resource usage')
     parser.add_argument('--stdout', type=Text, nargs='?', help='Output file name to tee standard output (CWL output object)')
     parser.add_argument('--stderr', type=Text, nargs='?', help='Output file name to tee standard error to (includes tool logs)')

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ bagit==1.7.0
 CacheControl==0.11.7
 cachetools==3.1.1
 certifi==2019.6.16
-cffi==1.12.3
+# cffi==1.12.3
 chardet==3.0.4
 coloredlogs==10.0
 coverage==4.5.4
@@ -35,7 +35,7 @@ pyparsing==2.4.2
 python-dateutil==2.8.0
 PyYAML==5.4
 rdflib>=4.2.2,<5.1
-rdflib-jsonld==0.4.0
+rdflib-jsonld==0.6.2
 requests==2.22.0
 requests-oauthlib==1.2.0
 rsa==4.7
@@ -46,5 +46,4 @@ shellescape>=3.4.1,<3.5
 six==1.12.0
 tenacity==5.1.1
 typing-extensions==3.7.4
-urllib3==1.26.5
 websocket-client==0.56.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # version checking derived from https://github.com/levlaz/circleci.py/blob/master/setup.py
 from setuptools.command.install import install
 
-VERSION = '0.11.0-t2test'
+VERSION = '0.11.0'
 TAG_ENV_VAR = 'CIRCLE_TAG'
 
 with open("README.md", "r") as fh:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -21,6 +21,15 @@ class CalrissianRuntimeContextTestCase(TestCase):
         labels = {'key1': 'val1'}
         ctx = CalrissianRuntimeContext({'pod_labels':labels})
         self.assertEqual(ctx.pod_labels, labels)
+        
+    def test_has_pod_nodeselectors_field(self):
+        ctx = CalrissianRuntimeContext()
+        self.assertIsNone(ctx.pod_nodeselectors)
+
+    def test_sets_nodeselectors_field(self):
+        nodeselectors = {'disktype': 'ssd'}
+        ctx = CalrissianRuntimeContext({'pod_nodeselectors':nodeselectors})
+        self.assertEqual(ctx.pod_nodeselectors, nodeselectors)
     
     def test_has_pod_env_vars_field(self):
         ctx = CalrissianRuntimeContext()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -284,10 +284,11 @@ class KubernetesPodBuilderTestCase(TestCase):
         self.stdin = 'stdin.txt'
         self.resources = {'cores': 1, 'ram': 1024}
         self.labels = {'key1': 'val1', 'key2': 123}
+        self.nodeselectors = {'disktype': 'ssd', 'cachelevel': 2}
         self.security_context = { 'runAsUser': os.getuid(),'runAsGroup': os.getgid() }
         self.pod_builder = KubernetesPodBuilder(self.name, self.container_image, self.environment, self.volume_mounts,
                                                 self.volumes, self.command_line, self.stdout, self.stderr, self.stdin,
-                                                self.resources, self.labels, self.security_context)
+                                                self.resources, self.labels, self.nodeselectors, self.security_context)
 
     @patch('calrissian.job.random_tag')
     def test_safe_pod_name(self, mock_random_tag):
@@ -345,6 +346,10 @@ class KubernetesPodBuilderTestCase(TestCase):
     def test_string_labels(self):
         self.pod_builder.labels = {'key1': 123}
         self.assertEqual(self.pod_builder.pod_labels(), {'key1':'123'})
+        
+    def test_string_nodeselectors(self):
+        self.pod_builder.nodeselectors = {'cachelevel': 2}
+        self.assertEqual(self.pod_builder.pod_nodeselectors(), {'cachelevel':'2'})
 
     def test_init_containers_empty_when_no_stdout_or_stderr(self):
         self.pod_builder.stdout = None
@@ -420,6 +425,10 @@ class KubernetesPodBuilderTestCase(TestCase):
                 ],
                 'restartPolicy': 'Never',
                 'volumes': self.volumes,
+                'nodeSelector': {
+                    "disktype": "ssd",
+                    "cachelevel": "2"
+                },
                 'securityContext': {
                     'runAsUser': os.getuid(),
                     'runAsGroup': os.getgid()
@@ -624,6 +633,7 @@ class CalrissianCommandLineJobTestCase(TestCase):
             job.stdin,
             job.builder.resources,
             mock_read_yaml.return_value,
+            mock_read_yaml.return_value,
             job.get_security_context(mock_runtime_context)
         ))
         # calls builder.build
@@ -785,6 +795,22 @@ class CalrissianCommandLineJobTestCase(TestCase):
         job = self.make_job()
         labels = job.get_pod_labels(mock_runtime_context)
         self.assertEqual(labels, {})
+        
+    @patch('calrissian.job.read_yaml')
+    def test_get_pod_nodeselectors(self, mock_read_yaml, mock_volume_builder, mock_client):
+        expected_nodeselectors = {'disktype':'ssd'}
+        mock_read_yaml.return_value = expected_nodeselectors
+        mock_runtime_context = Mock(pod_nodeselectors='nodeselectors.yaml')
+        job = self.make_job()
+        nodeselectors = job.get_pod_nodeselectors(mock_runtime_context)
+        self.assertEqual(nodeselectors, expected_nodeselectors)
+        self.assertEqual(mock_read_yaml.call_args, call('nodeselectors.yaml'))
+
+    def test_get_pod_nodeselectors_empty(self, mock_volume_builder, mock_client):
+        mock_runtime_context = Mock(pod_nodeselectors=None)
+        job = self.make_job()
+        nodeselectors = job.get_pod_nodeselectors(mock_runtime_context)
+        self.assertEqual(nodeselectors, {})
 
     @patch('calrissian.job.read_yaml')
     def test_get_pod_env_vars(self, mock_read_yaml, mock_volume_builder, mock_client):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -63,7 +63,7 @@ class CalrissianMainTestCase(TestCase):
     def test_add_arguments(self):
         mock_parser = Mock()
         add_arguments(mock_parser)
-        self.assertEqual(mock_parser.add_argument.call_count, 8)
+        self.assertEqual(mock_parser.add_argument.call_count, 9)
 
     @patch('calrissian.main.sys')
     def test_parse_arguments_exits_without_ram_or_cores(self, mock_sys):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -63,7 +63,7 @@ class CalrissianMainTestCase(TestCase):
     def test_add_arguments(self):
         mock_parser = Mock()
         add_arguments(mock_parser)
-        self.assertEqual(mock_parser.add_argument.call_count, 7)
+        self.assertEqual(mock_parser.add_argument.call_count, 8)
 
     @patch('calrissian.main.sys')
     def test_parse_arguments_exits_without_ram_or_cores(self, mock_sys):


### PR DESCRIPTION
## Related issues: #126

## Proposed Changes:

***Option to apply runtime node selectors to submitted pods spec***
This PR adds an argument `--pod-nodeselectors  <yaml_file>` that:
* Adds `CalrissianRuntimeContext` subclass with a pod_nodeselectors attribute
* `CalrissianCommandLineJob` function `get_pod_nodeselectors` reads the YAML (or JSON) file of environment variables and set the node selectors used by KubernetesPodBuilder to set the pod spec.


## PR Checklist:

- [X] Tested with nose2 
- [X] I have added my changes to a [CHANGELOG](https://github.com/Terradue/calrissian/blob/feature/nodeSelector/CHANGELOG.md).