### PR TITLE
Feature/pod-exit-code-logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ jobs:
           command: |
             . venv/bin/activate
             nose2
+          environment:
+            RETRY_ATTEMPTS: 10
   deploy:
     docker:
       - image: circleci/python:3.7

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ calrissian.egg-info/
 tests/__pycache__/
 .vscode
 env37
+build
+*.egg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- adds an argument `--tool-logs-basepath <local_folder_path>` that enable the tool to fetch the pod logs by tool specified in the workflow (PR #139)
+
+### Changed
+
+- contraints the pod to complete with a proper termination status or raise an exception. (PR #139)
 
 ## [v0.11.0] - 2022-11-10
 

--- a/calrissian/context.py
+++ b/calrissian/context.py
@@ -21,5 +21,5 @@ class CalrissianRuntimeContext(RuntimeContext):
         self.pod_env_vars = None
         self.pod_nodeselectors = None
         self.pod_serviceaccount = None
-        self.pod_logs = None
+        self.tool_logs_basepath = None
         return super(CalrissianRuntimeContext, self).__init__(kwargs)

--- a/calrissian/context.py
+++ b/calrissian/context.py
@@ -21,4 +21,5 @@ class CalrissianRuntimeContext(RuntimeContext):
         self.pod_env_vars = None
         self.pod_nodeselectors = None
         self.pod_serviceaccount = None
+        self.pod_logs = None
         return super(CalrissianRuntimeContext, self).__init__(kwargs)

--- a/calrissian/executor.py
+++ b/calrissian/executor.py
@@ -20,6 +20,10 @@ class InconsistentResourcesException(Exception):
     pass
 
 
+class IncompleteStatusException(Exception):
+    pass
+
+
 class Resources(object):
     """
     Class to encapsulate compute resources and provide arithmetic operations and comparisons

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -404,11 +404,11 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
         Dumps the pod logs
         """
         if runtime_context.pod_logs: 
-            log_filename = os.path.join(runtime_context.pod_logs, f"{completion_result.name}.log")
+            log_filename = os.path.join(runtime_context.pod_logs, f"{completion_result.pod_name}.log")
         else: 
-            log_filename = f"{completion_result.name}.log"
+            log_filename = f"{completion_result.pod_name}.log"
 
-        log.info(f"Writing pod {completion_result.name} logs to {log_filename}")
+        log.info(f"Writing pod {completion_result.pod_name} logs to {log_filename}")
                 
         with open(log_filename, 'w') as f:
             for log_entry in completion_result.pod_log:

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -399,6 +399,17 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
         report = TimedResourceReport.create(self.name, completion_result, disk_bytes)
         Reporter.add_report(report)
 
+    def dump_pod_logs(self, completion_result):
+        """
+        Dumps the pod logs
+        """
+        for pod_name in completion_result.pod_logs.keys():
+            log_filename = os.path.join(self.outdir, f"{pod_name}.log")
+            log.info(f"Writing pod {pod_name} logs to {log_filename}")
+            with open(log_filename, 'w') as f:
+                for log_entry in completion_result.pod_logs[pod_name]:
+                    f.write(f"{log_entry}\n")
+
     def finish(self, completion_result, runtimeContext):
         exit_code = completion_result.exit_code
         if exit_code in self.successCodes:
@@ -416,6 +427,8 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
 
         disk_bytes = total_size(outputs)
         self.report(completion_result, disk_bytes)
+
+        self.dump_pod_logs(completion_result)
 
         # Invoke the callback with a lock
         with runtimeContext.workflow_eval_lock:

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -137,7 +137,7 @@ class KubernetesClient(object):
             # kubernetes-client decodes them as utf-8 when _preload_content is True
             # https://github.com/kubernetes-client/python/blob/fcda6fe96beb21cd05522c17f7f08c5a7c0e3dc3/kubernetes/client/rest.py#L215-L216
             # So we do the same here
-            line = line.decode('utf-8').rstrip()
+            line = line.decode('utf-8', errors="ignore").rstrip()
             log.debug('[{}] {}'.format(pod_name, line))
         log.info('[{}] follow_logs end'.format(pod_name))
 

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -168,7 +168,10 @@ class KubernetesClient(object):
                 w.stop()
             else:
                 raise CalrissianJobException('Unexpected pod container status', status)
-        log.info('completion_result is {}', self.completion_result)
+        
+        if self.completion_result is None:
+            raise HTTPError
+
         return self.completion_result
 
     def _set_pod(self, pod):

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -48,8 +48,8 @@ class CompletionResult(object):
     The CPU and memory values should be in kubernetes units (strings).
     """
 
-    def __init__(self, name, exit_code, cpus, memory, start_time, finish_time, pod_log):
-        self.name = name
+    def __init__(self, pod_name, exit_code, cpus, memory, start_time, finish_time, pod_log):
+        self.pod_name = pod_name
         self.exit_code = exit_code
         self.cpus = cpus
         self.memory = memory

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -157,7 +157,7 @@ class KubernetesClient(object):
         log.info('[{}] follow_logs end'.format(pod_name))
 
 
-    @retry_exponential_if_exception_type((ApiException, HTTPError,), log)
+    @retry_exponential_if_exception_type((ApiException, HTTPError, IncompleteStatusException), log)
     def wait_for_completion(self) -> CompletionResult:
         w = watch.Watch()
         for event in w.stream(self.core_api_instance.list_namespaced_pod, self.namespace, field_selector=self._get_pod_field_selector()):

--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -148,7 +148,7 @@ class KubernetesClient(object):
             # So we do the same here
             line = line.decode('utf-8', errors="ignore").rstrip()
             log.debug('[{}] {}'.format(pod_name, line))
-            self.pod_log.append({"timestamp": datetime.utcnow().isoformat(), "entry": line})
+            self.pod_log.append({"timestamp": f"{datetime.utcnow().isoformat()}Z", "pod": pod_name, "entry": line})
         log.info('[{}] follow_logs end'.format(pod_name))
 
     @retry_exponential_if_exception_type((ApiException, HTTPError,), log)

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -39,7 +39,7 @@ def add_arguments(parser):
     parser.add_argument('--max-cores', type=str, help='Maximum number of CPU cores to use')
     parser.add_argument('--pod-labels', type=Text, nargs='?', help='YAML file of labels to add to Pods submitted')
     parser.add_argument('--pod-env-vars', type=Text, nargs='?', help='YAML file of environment variables to add at runtime to Pods submitted')
-    parser.add_argument('--pod-node-selectors', type=Text, nargs='?', help='YAML file of node selectors to add to Pods submitted')
+    parser.add_argument('--pod-nodeselectors', type=Text, nargs='?', help='YAML file of node selectors to add to Pods submitted')
     parser.add_argument('--pod-serviceaccount', type=str, help='Service Account to use for pods management')
     parser.add_argument('--usage-report', type=Text, nargs='?', help='Output JSON file name to record resource usage')
     parser.add_argument('--stdout', type=Text, nargs='?', help='Output file name to tee standard output (CWL output object)')

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -44,6 +44,7 @@ def add_arguments(parser):
     parser.add_argument('--usage-report', type=Text, nargs='?', help='Output JSON file name to record resource usage')
     parser.add_argument('--stdout', type=Text, nargs='?', help='Output file name to tee standard output (CWL output object)')
     parser.add_argument('--stderr', type=Text, nargs='?', help='Output file name to tee standard error to (includes tool logs)')
+    parser.add_argument('--pod-logs', type=Text, nargs='?', help='Base path for the pod logs')
 
 def print_version():
     print(version())

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -44,7 +44,7 @@ def add_arguments(parser):
     parser.add_argument('--usage-report', type=Text, nargs='?', help='Output JSON file name to record resource usage')
     parser.add_argument('--stdout', type=Text, nargs='?', help='Output file name to tee standard output (CWL output object)')
     parser.add_argument('--stderr', type=Text, nargs='?', help='Output file name to tee standard error to (includes tool logs)')
-    parser.add_argument('--pod-logs', type=Text, nargs='?', help='Base path for the pod logs')
+    parser.add_argument('--tool-logs-basepath', type=Text, nargs='?', help='Base path for saving the tool logs')
 
 def print_version():
     print(version())

--- a/calrissian/report.py
+++ b/calrissian/report.py
@@ -115,11 +115,11 @@ class TimedResourceReport(TimedReport):
     duration of the timed report. These values, by convention, are the kubernetes **requested**
     resources (not limits or actual).
     """
-    def __init__(self, cpus=0, ram_megabytes=0, disk_megabytes=0, pod_log=None, *args, **kwargs):
+    def __init__(self, cpus=0, ram_megabytes=0, disk_megabytes=0, exit_code=0, *args, **kwargs):
         self.cpus = cpus
         self.ram_megabytes = ram_megabytes
         self.disk_megabytes = disk_megabytes
-        self.pod_log = pod_log
+        self.exit_code = exit_code
         super(TimedResourceReport, self).__init__(*args, **kwargs)
 
     def ram_megabyte_hours(self):
@@ -140,19 +140,18 @@ class TimedResourceReport(TimedReport):
         result = super(TimedResourceReport, self).to_dict()
         result['ram_megabyte_hours'] = self.ram_megabyte_hours()
         result['cpu_hours'] = self.cpu_hours()
+        result['exit_code'] = self.exit_code
         return result
 
     @classmethod
-    def create(cls, pod_name, completion_result, runtime_context, disk_bytes):
+    def create(cls, name, completion_result, disk_bytes):
         cpus = CPUParser.parse(completion_result.cpus)
         ram_megabytes = MemoryParser.parse_to_megabytes(completion_result.memory)
         disk_megabytes = MemoryParser.parse_to_megabytes(str(disk_bytes))
-        if runtime_context.pod_logs: 
-            pod_log = os.path.join(runtime_context.pod_logs, f"{completion_result.pod_name}.log")
-        else: 
-            pod_log = f"{completion_result.pod_name}.log"
-        return cls(pod_name=pod_name, start_time=completion_result.start_time, finish_time=completion_result.finish_time, cpus=cpus,
-                   ram_megabytes=ram_megabytes, disk_megabytes=disk_megabytes, pod_log=pod_log)
+
+        return cls(name=name, start_time=completion_result.start_time, finish_time=completion_result.finish_time, cpus=cpus,
+                   ram_megabytes=ram_megabytes, disk_megabytes=disk_megabytes,
+                   exit_code=completion_result.exit_code)
 
 
 class Event(object):

--- a/calrissian/report.py
+++ b/calrissian/report.py
@@ -143,15 +143,15 @@ class TimedResourceReport(TimedReport):
         return result
 
     @classmethod
-    def create(cls, name, completion_result, runtime_context, disk_bytes):
+    def create(cls, pod_name, completion_result, runtime_context, disk_bytes):
         cpus = CPUParser.parse(completion_result.cpus)
         ram_megabytes = MemoryParser.parse_to_megabytes(completion_result.memory)
         disk_megabytes = MemoryParser.parse_to_megabytes(str(disk_bytes))
         if runtime_context.pod_logs: 
-            pod_log = os.path.join(runtime_context.pod_logs, f"{completion_result.name}.log")
+            pod_log = os.path.join(runtime_context.pod_logs, f"{completion_result.pod_name}.log")
         else: 
-            pod_log = f"{completion_result.name}.log"
-        return cls(name=name, start_time=completion_result.start_time, finish_time=completion_result.finish_time, cpus=cpus,
+            pod_log = f"{completion_result.pod_name}.log"
+        return cls(pod_name=pod_name, start_time=completion_result.start_time, finish_time=completion_result.finish_time, cpus=cpus,
                    ram_megabytes=ram_megabytes, disk_megabytes=disk_megabytes, pod_log=pod_log)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,4 @@ tenacity==5.1.1
 typing-extensions==3.7.4
 urllib3==1.26.5
 websocket-client==0.56.0
+filelock

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # version checking derived from https://github.com/levlaz/circleci.py/blob/master/setup.py
 from setuptools.command.install import install
 
-VERSION = '0.11.0-sprint1'
+VERSION = '0.11.0sprint1'
 TAG_ENV_VAR = 'CIRCLE_TAG'
 
 with open("README.md", "r") as fh:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # version checking derived from https://github.com/levlaz/circleci.py/blob/master/setup.py
 from setuptools.command.install import install
 
-VERSION = '0.10.0'
+VERSION = '0.11.0-sprint1'
 TAG_ENV_VAR = 'CIRCLE_TAG'
 
 with open("README.md", "r") as fh:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -463,8 +463,8 @@ class CalrissianCommandLineJobTestCase(TestCase):
         return job
 
     def make_completion_result(self, exit_code):
-        return create_autospec(CompletionResult, exit_code=exit_code, cpus='1', memory='1', start_time=Mock(),
-                        finish_time=Mock())
+        return create_autospec(CompletionResult, pod_name=self.name, exit_code=exit_code, cpus='1', memory='1', start_time=Mock(),
+                        finish_time=Mock(), pod_log='logs/')
 
     def test_constructor_calculates_persistent_volume_entries(self, mock_volume_builder, mock_client):
         self.make_job()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -636,7 +636,7 @@ class CalrissianCommandLineJobTestCase(TestCase):
             job.builder.resources,
             mock_read_yaml.return_value,
             mock_read_yaml.return_value,
-            job.get_security_context(mock_runtime_context)
+            job.get_security_context(mock_runtime_context),
             None
         ))
         # calls builder.build

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -385,14 +385,13 @@ class CompletionResultTestCase(TestCase):
         self.memory = Mock()
         self.start_time = Mock()
         self.finish_time = Mock()
-        self.pod_log = Mock()
+        self.tool_log = Mock()
 
     def test_init(self):
-        result = CompletionResult(self.pod_name, self.exit_code, self.cpus, self.memory, self.start_time, self.finish_time, self.pod_log)
-        self.assertEqual(result.pod_name, self.pod_name)
+        result = CompletionResult(self.exit_code, self.cpus, self.memory, self.start_time, self.finish_time, self.tool_log)
         self.assertEqual(result.exit_code, self.exit_code)
         self.assertEqual(result.cpus, self.cpus)
         self.assertEqual(result.memory, self.memory)
         self.assertEqual(result.start_time, self.start_time)
         self.assertEqual(result.finish_time, self.finish_time)
-        self.assertEqual(result.pod_log, self.pod_log)
+        self.assertEqual(result.tool_log, self.tool_log)

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -1,8 +1,9 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch, call, PropertyMock, create_autospec
-from kubernetes.client.models import V1Pod
+from kubernetes.client.models import V1Pod, V1ContainerStateTerminated, V1ContainerState
 from kubernetes.client.api_client import ApiException
 from kubernetes.config.config_exception import ConfigException
+from calrissian.executor import IncompleteStatusException
 from calrissian.k8s import load_config_get_namespace, KubernetesClient, CalrissianJobException, PodMonitor, delete_pods
 from calrissian.k8s import CompletionResult, read_file
 
@@ -85,8 +86,9 @@ class KubernetesClientTestCase(TestCase):
 
     @patch('calrissian.k8s.watch', autospec=True)
     def test_wait_calls_watch_pod_with_pod_name_field_selector(self, mock_watch, mock_get_namespace, mock_client):
-        self.setup_mock_watch(mock_watch)
         mock_pod = self.make_mock_pod('test123')
+        mock_pod.status.container_statuses[0].state = Mock(running=None, waiting=None, terminated=Mock(exit_code=0))
+        self.setup_mock_watch(mock_watch, [mock_pod])
         kc = KubernetesClient()
         kc._set_pod(mock_pod)
         kc.wait_for_completion()
@@ -95,12 +97,23 @@ class KubernetesClientTestCase(TestCase):
                                                      field_selector='metadata.name=test123'))
 
     @patch('calrissian.k8s.watch', autospec=True)
+    def test_wait_calls_watch_pod_with_imcomplete_status(self, mock_watch, mock_get_namespace, mock_client):
+        self.setup_mock_watch(mock_watch)
+        mock_pod = self.make_mock_pod('test123')
+        kc = KubernetesClient()
+        kc._set_pod(mock_pod)
+        # Assert IncompleteStatusException is raised
+        with self.assertRaises(IncompleteStatusException):
+            kc.wait_for_completion()
+
+    @patch('calrissian.k8s.watch', autospec=True)
     def test_wait_skips_pod_when_status_is_none(self, mock_watch, mock_get_namespace, mock_client):
         mock_pod = Mock(status=Mock(container_statuses=None))
         self.setup_mock_watch(mock_watch, [mock_pod])
         kc = KubernetesClient()
         kc._set_pod(Mock())
-        kc.wait_for_completion()
+        with self.assertRaises(IncompleteStatusException):
+            kc.wait_for_completion()
         self.assertFalse(mock_watch.Watch.return_value.stop.called)
         self.assertFalse(mock_client.CoreV1Api.return_value.delete_namespaced_pod.called)
         self.assertIsNotNone(kc.pod)
@@ -112,7 +125,8 @@ class KubernetesClientTestCase(TestCase):
         self.setup_mock_watch(mock_watch, [mock_pod])
         kc = KubernetesClient()
         kc._set_pod(Mock())
-        kc.wait_for_completion()
+        with self.assertRaises(IncompleteStatusException):
+            kc.wait_for_completion()
         self.assertFalse(mock_watch.Watch.return_value.stop.called)
         self.assertFalse(mock_client.CoreV1Api.return_value.delete_namespaced_pod.called)
         self.assertIsNotNone(kc.pod)
@@ -125,7 +139,8 @@ class KubernetesClientTestCase(TestCase):
         self.setup_mock_watch(mock_watch, [mock_pod])
         kc = KubernetesClient()
         kc._set_pod(Mock())
-        kc.wait_for_completion()
+        with self.assertRaises(IncompleteStatusException):
+            kc.wait_for_completion()
         self.assertFalse(mock_watch.Watch.return_value.stop.called)
         self.assertFalse(mock_client.CoreV1Api.return_value.delete_namespaced_pod.called)
         self.assertIsNotNone(kc.pod)

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -379,16 +379,20 @@ class PodMonitorTestCase(TestCase):
 class CompletionResultTestCase(TestCase):
 
     def setUp(self):
+        self.pod_name = Mock()
         self.exit_code = Mock()
         self.cpus = Mock()
         self.memory = Mock()
         self.start_time = Mock()
         self.finish_time = Mock()
+        self.pod_log = Mock()
 
     def test_init(self):
-        result = CompletionResult(self.exit_code, self.cpus, self.memory, self.start_time, self.finish_time)
+        result = CompletionResult(self.pod_name, self.exit_code, self.cpus, self.memory, self.start_time, self.finish_time, self.pod_log)
+        self.assertEqual(result.pod_name, self.pod_name)
         self.assertEqual(result.exit_code, self.exit_code)
         self.assertEqual(result.cpus, self.cpus)
         self.assertEqual(result.memory, self.memory)
         self.assertEqual(result.start_time, self.start_time)
         self.assertEqual(result.finish_time, self.finish_time)
+        self.assertEqual(result.pod_log, self.pod_log)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -63,7 +63,7 @@ class CalrissianMainTestCase(TestCase):
     def test_add_arguments(self):
         mock_parser = Mock()
         add_arguments(mock_parser)
-        self.assertEqual(mock_parser.add_argument.call_count, 9)
+        self.assertEqual(mock_parser.add_argument.call_count, 10)
 
     @patch('calrissian.main.sys')
     def test_parse_arguments_exits_without_ram_or_cores(self, mock_sys):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -63,7 +63,7 @@ class CalrissianMainTestCase(TestCase):
     def test_add_arguments(self):
         mock_parser = Mock()
         add_arguments(mock_parser)
-        self.assertEqual(mock_parser.add_argument.call_count, 8)
+        self.assertEqual(mock_parser.add_argument.call_count, 9)
 
     @patch('calrissian.main.sys')
     def test_parse_arguments_exits_without_ram_or_cores(self, mock_sys):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -98,8 +98,8 @@ class TimedResourceReportTestCase(TestCase):
         self.assertEqual(self.report.cpus, 0)
 
     def test_create(self):
-        completion_result = CompletionResult(0, '4', '3G', TIME_1000, TIME_1100)
         name = 'test-job'
+        completion_result = CompletionResult(name, 0, '4', '3G', TIME_1000, TIME_1100, "logs/")
         disk_bytes = 10000000
         report = TimedResourceReport.create(name, completion_result, disk_bytes)
         self.assertEqual(report.cpu_hours(), 4)
@@ -108,6 +108,7 @@ class TimedResourceReportTestCase(TestCase):
         self.assertEqual(report.finish_time, TIME_1100)
         self.assertEqual(report.name, 'test-job')
         self.assertEqual(report.disk_megabytes, 10)
+        self.assertEqual(report.pod_log, "logs/test-job.log")
 
     def test_to_dict(self):
         self.report.ram_megabytes = 1024

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -99,7 +99,7 @@ class TimedResourceReportTestCase(TestCase):
 
     def test_create(self):
         name = 'test-job'
-        completion_result = CompletionResult(name, 0, '4', '3G', TIME_1000, TIME_1100, "logs/")
+        completion_result = CompletionResult(0, '4', '3G', TIME_1000, TIME_1100, [])
         disk_bytes = 10000000
         report = TimedResourceReport.create(name, completion_result, disk_bytes)
         self.assertEqual(report.cpu_hours(), 4)
@@ -108,18 +108,21 @@ class TimedResourceReportTestCase(TestCase):
         self.assertEqual(report.finish_time, TIME_1100)
         self.assertEqual(report.name, 'test-job')
         self.assertEqual(report.disk_megabytes, 10)
-        self.assertEqual(report.pod_log, "logs/test-job.log")
+        self.assertEqual(report.exit_code, 0)
+
 
     def test_to_dict(self):
         self.report.ram_megabytes = 1024
         self.report.disk_megabytes = 512
         self.report.cpus = 8
+        self.report.exit_code = 0
         report_dict = self.report.to_dict()
         self.assertEqual(report_dict['start_time'], TIME_1000)
         self.assertEqual(report_dict['finish_time'], TIME_1015)
         self.assertEqual(report_dict['cpu_hours'], 2)
         self.assertEqual(report_dict['ram_megabyte_hours'], 256)
         self.assertEqual(report_dict['disk_megabytes'], 512)
+        self.assertEqual(report_dict['exit_code'], 0)
         self.assertEqual(report_dict['name'], 'timed-resource-report')
 
 


### PR DESCRIPTION
## Proposed Changes:

***Option to apply runtime node selectors to submitted pods spec***
This PR adds an argument `--tool-logs-basepath  <local_folder_path>` that enable the tool to fetch the pod logs by tool specified in the workflow
This PR also contraints the pod to complete with a proper termination status or raise an exception. Previous behaviour was to skip pod completion result leading to an error further reading the completion result.

## PR Checklist:

- [X] Tested with nose2 
- [X] I have added my changes to a [CHANGELOG](https://github.com/Terradue/calrissian/blob/feature/nodeSelector/CHANGELOG.md).