### PR TITLE
Add self-delete managing options for Calrissian execution

### DIFF
--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -1,7 +1,7 @@
 from calrissian.executor import ThreadPoolJobExecutor
 from calrissian.context import CalrissianLoadingContext, CalrissianRuntimeContext
 from calrissian.version import version
-from calrissian.k8s import delete_pods
+from calrissian.k8s import delete_pods, patch_delete
 from calrissian.report import initialize_reporter, write_report, CPUParser, MemoryParser
 from cwltool.main import main as cwlmain
 from cwltool.argparser import arg_parser
@@ -45,6 +45,7 @@ def add_arguments(parser):
     parser.add_argument('--stdout', type=Text, nargs='?', help='Output file name to tee standard output (CWL output object)')
     parser.add_argument('--stderr', type=Text, nargs='?', help='Output file name to tee standard error to (includes tool logs)')
     parser.add_argument('--tool-logs-basepath', type=Text, nargs='?', help='Base path for saving the tool logs')
+    parser.add_argument('--self-delete', type=bool, default=False, help='Delete the pod after the workflow is completed')    
 
 def print_version():
     print(version())
@@ -131,9 +132,10 @@ def main():
         if parsed_args.usage_report:
             write_report(parsed_args.usage_report)
         flush_tees()
+        if parsed_args.self_delete:
+            patch_delete()
 
     return result
 
-
 if __name__ == '__main__':
-    sys.exit(main())
+    main()

--- a/examples/CalrissianJob-revsort-single.yaml
+++ b/examples/CalrissianJob-revsort-single.yaml
@@ -8,7 +8,8 @@ spec:
     spec:
       containers:
       - name: calrissian
-        image: dukegcb/calrissian:latest
+        # image: dukegcb/calrissian:latest
+        image: commanderblop/haha:v1.9
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
@@ -22,6 +23,8 @@ spec:
           - "/calrissian/tmpout/"
           - "--outdir"
           - "/calrissian/output-data/"
+          - "--self-delete"
+          - "True"
           - "/calrissian/input-data/revsort-single.cwl"
           - "/calrissian/input-data/revsort-single-job.json"
         volumeMounts:

--- a/examples/CalrissianJob-revsort.yaml
+++ b/examples/CalrissianJob-revsort.yaml
@@ -8,7 +8,9 @@ spec:
     spec:
       containers:
       - name: calrissian
-        image: dukegcb/calrissian:latest
+        # image: dukegcb/calrissian:latest
+        image: commanderblop/haha
+        imagePullPolicy: Never
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/examples/ServiceAccount.yaml
+++ b/examples/ServiceAccount.yaml
@@ -6,7 +6,7 @@ metadata:
 rules:
 - apiGroups: ["", "batch", '\'] # "" indicates the core API group
   resources: ["pods", "jobs"]
-  verbs: ["get", "watch", "list", "apply", "create"]
+  verbs: ["get", "watch", "list", "apply", "create", "patch", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 # This role binding allows "jane" to read pods in the "default" namespace.

--- a/examples/ServiceAccount.yaml
+++ b/examples/ServiceAccount.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: # namespace here
+  name: pod-reader
+rules:
+- apiGroups: ["", "batch", '\'] # "" indicates the core API group
+  resources: ["pods", "jobs"]
+  verbs: ["get", "watch", "list", "apply", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# This role binding allows "jane" to read pods in the "default" namespace.
+# You need to already have a Role named "pod-reader" in that namespace.
+kind: RoleBinding
+metadata:
+  name: read-pods
+  namespace: # namespace here
+subjects:
+# You can specify more than one "subject"
+- kind: ServiceAccount
+  name: default
+  namespace: ""
+roleRef:
+  # "roleRef" specifies the binding to a Role / ClusterRole
+  kind: Role #this must be Role or ClusterRole
+  name: pod-reader # this must match the name of the Role or ClusterRole you wish to bind to
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Created additional command line argument "--self-delete" that defaults to False.

First, run ServiceAccount.yaml to grant coreV1API additional permission to monitor and patch job.

Second, set "--self-delete" to "True" in the command line argument to enable self deletion 5 seconds after the job is complete.

Changes: patch_delete() created at the bottom of k8s.py and used in main.py. 

