### PR TITLE
gpu-extension-evo: proper support for GPU

### DIFF
--- a/calrissian/context.py
+++ b/calrissian/context.py
@@ -22,4 +22,5 @@ class CalrissianRuntimeContext(RuntimeContext):
         self.pod_nodeselectors = None
         self.pod_serviceaccount = None
         self.tool_logs_basepath = None
+        self.max_gpus = None
         return super(CalrissianRuntimeContext, self).__init__(kwargs)

--- a/calrissian/executor.py
+++ b/calrissian/executor.py
@@ -30,7 +30,7 @@ class Resources(object):
     """
     RAM = 'ram'
     CORES = 'cores'
-    GPUS = 'cudaDeviceCount'
+    GPUS = 'gpus'
 
     def __init__(self, ram=0, cores=0, gpus=0):
         self.ram = ram
@@ -169,7 +169,7 @@ class ThreadPoolJobExecutor(JobExecutor):
     Relevant: https://github.com/common-workflow-language/cwltool/issues/888
     """
 
-    def __init__(self, total_ram, total_cores, total_gpus, max_workers=None):
+    def __init__(self, total_ram, total_cores, total_gpus=0, max_workers=None):
         """
         Initialize a ThreadPoolJobExecutor
         :param total_ram: RAM limit in megabytes for concurrent jobs

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -323,15 +323,13 @@ class KubernetesPodBuilder(object):
             if requirement["class"] in ['cwltool:CUDARequirement', 'http://commonwl.org/cwltool#CUDARequirement']:
                 log.debug('Adding CUDARequirement resources spec')
 
-                cuda_device_count = max(requirement["cudaDeviceCountMin"], requirement["cudaDeviceCountMax"])
-
                 resource_bound = 'requests'
-                container_resources[resource_bound]['nvidia.com/gpu'] = str(cuda_device_count)
+                container_resources[resource_bound]['nvidia.com/gpu'] = str(requirement["cudaDeviceCountMin"])
                 if "limits" in container_resources:
                     resource_bound = 'limits'
-                    container_resources[resource_bound]['nvidia.com/gpu'] = str(cuda_device_count)
+                    container_resources[resource_bound]['nvidia.com/gpu'] = str(requirement["cudaDeviceCountMax"])
                 else:
-                    container_resources['limits'] = {'nvidia.com/gpu': str(cuda_device_count)}
+                    container_resources['limits'] = {'nvidia.com/gpu': str(requirement["cudaDeviceCountMax"])}
 
         return container_resources
 
@@ -494,6 +492,8 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
                 # if --max-gpus is set, set cudaDeviceCount to 1 
                 # to pass the cwltool job.py check
                 self.builder.resources["cudaDeviceCount"] = max(cuda_req["cudaDeviceCountMin"], cuda_req["cudaDeviceCountMax"])  
+                self.builder.resources["cudaDeviceCountMin"] = cuda_req["cudaDeviceCountMin"]
+                self.builder.resources["cudaDeviceCountMax"] = cuda_req["cudaDeviceCountMax"]
             else:
                 raise WorkflowException('Error: set --max-gpus to run CWL files with the CUDARequirement')
 

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -1,6 +1,7 @@
 from typing import Dict
 from cwltool.job import ContainerCommandLineJob, needs_shell_quoting_re
 
+# override cwltool.cuda.cuda_check
 def _cuda_check(cuda_req, requestCount):
     return 1
 

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -39,6 +39,7 @@ def activate_logging(level):
 def add_arguments(parser):
     parser.add_argument('--max-ram', type=str, help='Maximum amount of RAM to use, e.g 1048576, 512Mi or 2G. Follows k8s resource conventions')
     parser.add_argument('--max-cores', type=str, help='Maximum number of CPU cores to use')
+    parser.add_argument('--max-gpus', type=str, nargs='?', help='Maximum number of GPU cores to use')
     parser.add_argument('--pod-labels', type=Text, nargs='?', help='YAML file of labels to add to Pods submitted')
     parser.add_argument('--pod-env-vars', type=Text, nargs='?', help='YAML file of environment variables to add at runtime to Pods submitted')
     parser.add_argument('--pod-nodeselectors', type=Text, nargs='?', help='YAML file of node selectors to add to Pods submitted')
@@ -48,6 +49,7 @@ def add_arguments(parser):
     parser.add_argument('--stderr', type=Text, nargs='?', help='Output file name to tee standard error to (includes tool logs)')
     parser.add_argument('--tool-logs-basepath', type=Text, nargs='?', help='Base path for saving the tool logs')
     parser.add_argument('--conf', help='Defines the default values for the CLI arguments', action='append')
+
 
 def print_version():
     print(version())

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -132,7 +132,8 @@ def main():
     install_tees(parsed_args.stdout, parsed_args.stderr)
     max_ram_megabytes = MemoryParser.parse_to_megabytes(parsed_args.max_ram)
     max_cores = CPUParser.parse(parsed_args.max_cores)
-    executor = ThreadPoolJobExecutor(max_ram_megabytes, max_cores)
+    max_gpus = int(parsed_args.max_gpus) if parsed_args.max_gpus else 0
+    executor = ThreadPoolJobExecutor(max_ram_megabytes, max_cores, max_gpus)
     initialize_reporter(max_ram_megabytes, max_cores)
     runtime_context = CalrissianRuntimeContext(vars(parsed_args))
     runtime_context.select_resources = executor.select_resources

--- a/calrissian/tool.py
+++ b/calrissian/tool.py
@@ -46,6 +46,7 @@ class CalrissianCommandLineTool(CommandLineTool):
                 'class': 'DockerRequirement',
                 'dockerPull': default_container
             })
+        
         return CalrissianCommandLineJob
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cwltool==3.1.20230201224320
+cwltool==3.1.20230601100705
 freezegun==0.3.12
 kubernetes==10.0.1
 mypy-extensions==0.4.3

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'urllib3>=1.24.2,<1.27',
         'kubernetes==10.0.1',
-        'cwltool==3.1.20230201224320',
+        'cwltool==3.1.20230601100705',
         'tenacity==5.1.1',
         'importlib-metadata<5,>=0.23'
     ],

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -15,12 +15,12 @@ def make_mock_job(resources):
 class ResourcesTestCase(TestCase):
 
     def setUp(self):
-        self.resource11 = Resources(1, 1)
-        self.resource22 = Resources(2, 2)
-        self.resource33 = Resources(3, 3)
-        self.resource21 = Resources(2, 1)
-        self.resource12 = Resources(1, 2)
-        self.resource_neg = Resources(-1, 0)
+        self.resource11 = Resources(1, 1, 1)
+        self.resource22 = Resources(2, 2, 2)
+        self.resource33 = Resources(3, 3, 3)
+        self.resource21 = Resources(2, 1, 2)
+        self.resource12 = Resources(1, 2, 1)
+        self.resource_neg = Resources(-1, 0, 0)
 
     def test_init(self):
         self.assertEqual(self.resource11.cores, 1)
@@ -66,26 +66,27 @@ class ResourcesTestCase(TestCase):
         self.assertFalse(self.resource33 <= self.resource22)
 
     def test_eq(self):
-        other = Resources(1, 1)
+        other = Resources(1, 1, 1)
         self.assertEqual(self.resource11, other)
 
     def test_from_job(self):
-        mock_job = make_mock_job(Resources(4, 2))
+        mock_job = make_mock_job(Resources(4, 2, 1))
         result = Resources.from_job(mock_job)
         self.assertEqual(result.ram, 4)
         self.assertEqual(result.cores, 2)
 
     def test_from_job_defaults_empty_without_builder(self):
-        mock_job = make_mock_job(Resources(4, 2))
+        mock_job = make_mock_job(Resources(4, 2, 1))
         del mock_job.builder
         result = Resources.from_job(mock_job)
         self.assertEqual(result.ram, 0)
         self.assertEqual(result.cores, 0)
 
     def test_from_dict(self):
-        result = Resources.from_dict({'cores': 3, 'ram': 400})
+        result = Resources.from_dict({'cores': 3, 'ram': 400, 'gpus': 1})
         self.assertEqual(result.cores, 3)
         self.assertEqual(result.ram, 400)
+        self.assertEqual(result.gpus, 1)
 
     def test_min(self):
         result = Resources.min(self.resource21, self.resource12)
@@ -221,12 +222,12 @@ class JobResourceQueueTestCase(TestCase):
 class ThreadPoolJobExecutorTestCase(TestCase):
 
     def setUp(self):
-        self.executor = ThreadPoolJobExecutor(1000, 2)
+        self.executor = ThreadPoolJobExecutor(1000, 2, 2)
         self.workflow_exception = WorkflowException('workflow exception')
         self.logger = Mock()
 
     def test_init(self):
-        expected_resources = Resources(1000, 2)
+        expected_resources = Resources(1000, 2, 2)
         self.assertEqual(self.executor.total_resources, expected_resources)
         self.assertEqual(self.executor.available_resources, expected_resources)
         self.assertIsNone(self.executor.max_workers)
@@ -257,13 +258,13 @@ class ThreadPoolJobExecutorTestCase(TestCase):
         self.assertEqual(result['cores'], 1) # when cpu max requested is below total, result should be requested
 
     def test_allocate(self):
-        resource = Resources(200, 1)
+        resource = Resources(200, 1, 1)
         self.executor.allocate(resource, self.logger)
-        self.assertEqual(self.executor.available_resources, Resources(800, 1))
+        self.assertEqual(self.executor.available_resources, Resources(800, 1, 1))
 
     def test_restore(self):
-        resource = Resources(200, 1)
-        self.executor.available_resources = Resources(800, 1)
+        resource = Resources(200, 1, 1)
+        self.executor.available_resources = Resources(800, 1, 1)
         self.executor.restore(resource, self.logger)
         self.assertEqual(self.executor.available_resources, self.executor.total_resources)
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -345,18 +345,18 @@ class KubernetesPodBuilderTestCase(TestCase):
         self.assertEqual(expected, resources)
         
     def test_gpu_hints(self):
-        self.pod_builder.resources = {'cores': 2, 'ram': 256}
-        self.pod_builder.hints = [OrderedDict([("class", "cwltool:CUDARequirement"), ("cudaVersionMin", '10.0'), ("cudaComputeCapability", '3.0'), ("cudaDeviceCountMin", 1), ("cudaDeviceCountMax", 1)])]
+        self.pod_builder.resources = {'cores': 2, 'ram': 256 }
+        self.pod_builder.requirements = [OrderedDict([("class", "cwltool:CUDARequirement"), ("cudaVersionMin", '10.0'), ("cudaComputeCapability", '3.0'), ("cudaDeviceCountMin", 1), ("cudaDeviceCountMax", 1)])]
 
         resources = self.pod_builder.container_resources()
         expected = {
             'requests': {
                 'cpu': '2', 
                 'memory': '256Mi',
-                'nvidia.com/gpu': '1'
+                'nvidia.com/gpu': '2'
             }, 
             "limits": {
-                'nvidia.com/gpu': '1'
+                'nvidia.com/gpu': '4'
             }
         }
         self.assertEqual(expected, resources)
@@ -507,12 +507,12 @@ class CalrissianCommandLineJobTestCase(TestCase):
         self.requirements = [{'class': 'DockerRequirement', 'dockerBuild': 'FROM ubuntu:latest\n'}]
         job = self.make_job()
         with self.assertRaisesRegex(UnsupportedRequirement, 'DockerRequirement.dockerBuild is not supported'):
-            job.check_requirements()
+            job.check_requirements(self.runtime_context)
 
     def test_check_requirements_ok_with_empty_requirements(self, mock_volume_builder, mock_client):
         self.requirements = []
         job = self.make_job()
-        job.check_requirements()
+        job.check_requirements(self.runtime_context)
 
     @patch('calrissian.job.os')
     def test_makes_tmpdir_when_not_exists(self, mock_os, mock_volume_builder, mock_client):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -353,14 +353,14 @@ class KubernetesPodBuilderTestCase(TestCase):
             'requests': {
                 'cpu': '2', 
                 'memory': '256Mi',
-                'nvidia.com/gpu': '2'
+                'nvidia.com/gpu': '1'
             }, 
             "limits": {
-                'nvidia.com/gpu': '4'
+                'nvidia.com/gpu': '1'
             }
         }
         self.assertEqual(expected, resources)
-        self.pod_builder.hints = [OrderedDict([("class", "cwltool:CUDARequirement"), ("cudaVersionMin", '10.0'), ("cudaComputeCapability", '3.0'), ("cudaDeviceCountMin", 2), ("cudaDeviceCountMax", 4)])]
+        self.pod_builder.requirements = [OrderedDict([("class", "cwltool:CUDARequirement"), ("cudaVersionMin", '10.0'), ("cudaComputeCapability", '3.0'), ("cudaDeviceCountMin", 2), ("cudaDeviceCountMax", 4)])]
 
         resources = self.pod_builder.container_resources()
         expected = {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,7 +44,7 @@ class CalrissianMainTestCase(TestCase):
         self.assertEqual(mock_memory_parser.parse_to_megabytes.call_args, call(mock_parse_arguments.return_value.max_ram))
         self.assertEqual(mock_cpu_parser.parse.call_args, call(mock_parse_arguments.return_value.max_cores))
         self.assertEqual(mock_executor.call_args,
-                         call(mock_memory_parser.parse_to_megabytes.return_value, mock_cpu_parser.parse.return_value))
+                         call(mock_memory_parser.parse_to_megabytes.return_value, mock_cpu_parser.parse.return_value, 1))
         self.assertTrue(mock_runtime_context.called)
         self.assertEqual(mock_cwlmain.call_args, call(args=mock_parse_arguments.return_value,
                                                       executor=mock_executor.return_value,
@@ -63,7 +63,7 @@ class CalrissianMainTestCase(TestCase):
     def test_add_arguments(self):
         mock_parser = Mock()
         add_arguments(mock_parser)
-        self.assertEqual(mock_parser.add_argument.call_count, 11)
+        self.assertEqual(mock_parser.add_argument.call_count, 12)
 
     @patch('calrissian.main.sys')
     def test_parse_arguments_exits_without_ram_or_cores(self, mock_sys):


### PR DESCRIPTION
This PR replaces the broken GPU support  introduced 0.14. 
It adds a CLI option --max-gpus to set the maximum number of GPU to use. 
It works as --max-ram, --max-cores but it is optional and to be used when the CWL description uses the cwltool#CUDARequirement extension
