### PR TITLE
Fixes calrissian #181

### DIFF
--- a/calrissian/context.py
+++ b/calrissian/context.py
@@ -23,6 +23,6 @@ class CalrissianRuntimeContext(RuntimeContext):
         self.pod_serviceaccount = None
         self.tool_logs_basepath = None
         self.max_gpus = None
-        self.no_network_access_pod_label = None
-        self.network_access_pod_label = None
+        self.no_network_access_pod_labels = None
+        self.network_access_pod_labels = None
         return super(CalrissianRuntimeContext, self).__init__(kwargs)

--- a/calrissian/context.py
+++ b/calrissian/context.py
@@ -23,4 +23,6 @@ class CalrissianRuntimeContext(RuntimeContext):
         self.pod_serviceaccount = None
         self.tool_logs_basepath = None
         self.max_gpus = None
+        self.no_network_access_pod_label = None
+        self.network_access_pod_label = None
         return super(CalrissianRuntimeContext, self).__init__(kwargs)

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -198,8 +198,10 @@ class KubernetesVolumeBuilder(object):
 
 class KubernetesPodBuilder(object):
 
-    def __init__(self, name, container_image, environment, volume_mounts, volumes, command_line, stdout, stderr, stdin, resources, labels, nodeselectors, security_context, serviceaccount, requirements=None, hints=None):
+    def __init__(self, name, builder, container_image, environment, volume_mounts, volumes, command_line, stdout, stderr, stdin, labels, nodeselectors, security_context, serviceaccount, no_network_access_pod_label={}, network_access_pod_label={}):
         self.name = name
+        self.builder = builder
+        self.cwl_version = self.builder.cwlVersion
         self.container_image = container_image
         self.environment = environment
         self.volume_mounts = volume_mounts
@@ -208,13 +210,15 @@ class KubernetesPodBuilder(object):
         self.stdout = stdout
         self.stderr = stderr
         self.stdin = stdin
-        self.resources = resources
+        self.resources = self.builder.resources
         self.labels = labels
         self.nodeselectors = nodeselectors
         self.security_context = security_context
         self.serviceaccount = serviceaccount
-        self.requirements = {} if requirements is None else requirements
-        self.hints = [] if hints is None else hints
+        self.no_network_access_pod_label = no_network_access_pod_label
+        self.network_access_pod_label = network_access_pod_label
+        self.requirements = {} if self.builder.requirements is None else self.builder.requirements
+        self.hints = [] if self.builder.hints is None else self.builder.hints
 
     def pod_name(self):
         tag = random_tag()
@@ -340,6 +344,22 @@ class KubernetesPodBuilder(object):
         Submitted labels must be strings
         :return:
         """
+        if self.cwl_version in ["v1.0"]:
+            network_access = True
+        else: 
+            network_access = False
+
+        for requirement in self.requirements:
+            if requirement["class"] in ["NetworkAccess"]:
+                network_access = requirement.get("networkAccess")
+                break
+        
+        if not network_access and self.no_network_access_pod_label: 
+            self.labels = {**self.labels, **self.no_network_access_pod_label}
+
+        if network_access and self.network_access_pod_label:
+            self.labels = {**self.labels, **self.network_access_pod_label}
+
         return {str(k): str(v) for k, v in self.labels.items()}
     
     def pod_nodeselectors(self):
@@ -515,7 +535,19 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
             return read_yaml(runtimeContext.pod_labels)
         else:
             return {}
-    
+
+    def get_network_access_pod_label(self, runtimeContext):
+        if runtimeContext.network_access_pod_label:
+            return read_yaml(runtimeContext.network_access_pod_label)
+        else:
+            return {}
+
+    def get_no_network_access_pod_label(self, runtimeContext):
+        if runtimeContext.no_network_access_pod_label:
+            return read_yaml(runtimeContext.no_network_access_pod_label)
+        else:
+            return {}
+
     def get_pod_nodeselectors(self, runtimeContext):
         if runtimeContext.pod_nodeselectors:
             return read_yaml(runtimeContext.pod_nodeselectors)
@@ -576,6 +608,7 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
 
         k8s_builder = KubernetesPodBuilder(
             self.name,
+            self.builder,
             self._get_container_image(),
             self.environment,
             self.volume_builder.volume_mounts,
@@ -584,13 +617,12 @@ class CalrissianCommandLineJob(ContainerCommandLineJob):
             self.stdout,
             self.stderr,
             self.stdin,
-            self.builder.resources,
             self.get_pod_labels(runtimeContext),
             self.get_pod_nodeselectors(runtimeContext),
             self.get_security_context(runtimeContext),
             self.get_pod_serviceaccount(runtimeContext),
-            self.builder.requirements,
-            self.builder.hints
+            self.get_no_network_access_pod_label(runtimeContext),
+            self.get_network_access_pod_label(runtimeContext),
         )
         built = k8s_builder.build()
         log.debug('{}\n{}{}\n'.format('-' * 80, yaml.dump(built), '-' * 80))

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -49,6 +49,8 @@ def add_arguments(parser):
     parser.add_argument('--stderr', type=Text, nargs='?', help='Output file name to tee standard error to (includes tool logs)')
     parser.add_argument('--tool-logs-basepath', type=Text, nargs='?', help='Base path for saving the tool logs')
     parser.add_argument('--conf', help='Defines the default values for the CLI arguments', action='append')
+    parser.add_argument('--no-network-access-pod-label', type=Text, nargs='?', help='YAML file to set the pod label to use for disabling network access')
+    parser.add_argument('--network-access-pod-label', type=Text, nargs='?', help='YAML file to set the pod label to use for enabling network access')
 
 
 def print_version():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -63,7 +63,7 @@ class CalrissianMainTestCase(TestCase):
     def test_add_arguments(self):
         mock_parser = Mock()
         add_arguments(mock_parser)
-        self.assertEqual(mock_parser.add_argument.call_count, 12)
+        self.assertEqual(mock_parser.add_argument.call_count, 14)
 
     @patch('calrissian.main.sys')
     def test_parse_arguments_exits_without_ram_or_cores(self, mock_sys):


### PR DESCRIPTION
This PR adds command line interface options to set network access pod labels.

These labels can be defined in NetworkPolicies to control the pod egress based on the CWL NetworkAccess requirement introduced in v1.1.