### PR TITLE
fix: issue #144 - requests and limits resources on pod

### DIFF
--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -292,9 +292,9 @@ class KubernetesPodBuilder(object):
 
     @staticmethod
     def resource_type(cwl_field):
-        if cwl_field == 'cores':
+        if cwl_field in [ 'cores', 'coresMax' ]:
             return 'cpu'
-        elif cwl_field == 'ram':
+        elif cwl_field in [ 'ram', 'ramMax' ]:
             return 'memory'
         else:
             return None
@@ -312,13 +312,24 @@ class KubernetesPodBuilder(object):
         log.debug(f'Building resources spec from {self.resources}')
         container_resources = {}
         for cwl_field, cwl_value in self.resources.items():
-            resource_bound = 'requests'
-            resource_type = self.resource_type(cwl_field)
-            resource_value = self.resource_value(resource_type, cwl_value)
-            if resource_type and resource_value:
-                if not container_resources.get(resource_bound):
-                    container_resources[resource_bound] = {}
-                container_resources[resource_bound][resource_type] = resource_value
+
+            if cwl_field in ['cores', 'ram']:
+                resource_bound = 'requests'
+                resource_type = self.resource_type(cwl_field)
+                resource_value = self.resource_value(resource_type, cwl_value)
+                if resource_type and resource_value:
+                    if not container_resources.get(resource_bound):
+                        container_resources[resource_bound] = {}
+                    container_resources[resource_bound][resource_type] = resource_value
+
+            elif cwl_field in ['coresMax', 'ramMax']:
+                resource_bound = 'limits'
+                resource_type = self.resource_type(cwl_field)
+                resource_value = self.resource_value(resource_type, cwl_value)
+                if resource_type and resource_value:
+                    if not container_resources.get(resource_bound):
+                        container_resources[resource_bound] = {}
+                    container_resources[resource_bound][resource_type] = resource_value
 
         # Add CUDA requirements from CWL
         for requirement in self.requirements:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -254,8 +254,21 @@ class ThreadPoolJobExecutorTestCase(TestCase):
         }
 
         result = self.executor.select_resources(request, Mock())
-        self.assertEqual(result['ram'], 1000) # When ram max requested exceeds total, result should be total
-        self.assertEqual(result['cores'], 1) # when cpu max requested is below total, result should be requested
+        self.assertEqual(result['ramMax'], 1000) # When ram max requested exceeds total, result should be total
+        self.assertEqual(result['coresMax'], 1) # when cpu max requested is below total, result should be requested
+
+    def test_requested_and_limit_resources(self):
+        request = {
+            'ramMin': 500,
+            'ramMax': 1000,
+            'coresMin': 1,
+            'coresMax': 2
+        }
+        result = self.executor.select_resources(request, Mock())
+        self.assertEqual(result['ram'], 500)
+        self.assertEqual(result['cores'], 1)
+        self.assertEqual(result['ramMax'], 1000)
+        self.assertEqual(result['coresMax'], 2)
 
     def test_allocate(self):
         resource = Resources(200, 1, 1)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -343,7 +343,22 @@ class KubernetesPodBuilderTestCase(TestCase):
             }
         }
         self.assertEqual(expected, resources)
-        
+    
+    def test_container_resources_requests_limits(self):
+        self.pod_builder.resources = {'cores': 2, 'ram': 256, 'ramMax': 4096, 'coresMax': 4}
+        resources = self.pod_builder.container_resources()
+        expected = {
+            'requests': {
+                'cpu': '2',
+                'memory': '256Mi'
+            },
+            'limits': {
+                'cpu': '4',
+                'memory': '4096Mi'
+            }
+        }
+        self.assertEqual(expected, resources)
+
     def test_gpu_hints(self):
         self.pod_builder.resources = {'cores': 2, 'ram': 256 }
         self.pod_builder.requirements = [OrderedDict([("class", "cwltool:CUDARequirement"), ("cudaVersionMin", '10.0'), ("cudaComputeCapability", '3.0'), ("cudaDeviceCountMin", 1), ("cudaDeviceCountMax", 1)])]


### PR DESCRIPTION
### Summary
This PR addresses issue #144 by improving how CWL resource requirements are handled when scheduling pods
### Details
Fully supports CWL requirements: ramMin, ramMax, coresMin, and coresMax

When all four are present:

- **ramMin** and **coresMin** are applied as resource **requests**

- **ramMax** and **coresMax** are applied as resource **limits**

### Testing

- All existing tests pass

- Added 2 new tests to validate the updated resource handling logic