### PR TITLE
feature: allow to disable streaming logs back to calrissian pods

### DIFF
--- a/calrissian/k8s.py
+++ b/calrissian/k8s.py
@@ -87,17 +87,34 @@ class KubernetesClient(object):
             monitor.add(pod)
             self._set_pod(pod)
 
+    @staticmethod
+    def get_bool_env_var(env_var_name: str, default: bool) -> bool:
+        """
+        Get an environment variable that signals a boolean (true or false) condition.
+        If the environment variable is not defined the default is returned
+        """
+        bool_string_value = os.getenv(env_var_name, f'{default}')
+        if str.lower(bool_string_value) in ['false', 'no', '0']:
+            return False
+        else:
+            return True
+
     def should_delete_pod(self):
         """
         Decide whether or not to delete a pod. Defaults to True if unset.
         Checks the CALRISSIAN_DELETE_PODS environment variable
         :return:
         """
-        delete_pods = os.getenv('CALRISSIAN_DELETE_PODS', '')
-        if str.lower(delete_pods) in ['false', 'no', '0']:
-            return False
-        else:
-            return True
+        return self.get_bool_env_var('CALRISSIAN_DELETE_PODS', default=True)
+    
+    def should_stream_logs(self):
+        """
+        Decide whether to stream cwl worker pod logs. Defaults to True if unset.
+        Checks the CALRISSIAN_STREAM_LOGS environment variable
+
+        When having a log shipper this disablement can be convenient to avoid duplicate logs.
+        """
+        return self.get_bool_env_var('CALRISSIAN_STREAM_LOGS', default=True)
 
     @retry_exponential_if_exception_type((ApiException, HTTPError,), log)
     def delete_pod_name(self, pod_name):
@@ -172,7 +189,8 @@ class KubernetesClient(object):
                 continue
             elif self.state_is_running(status.state):
                 # Can only get logs once container is running
-                self.follow_logs() # This will not return until pod completes
+                if self.should_stream_logs():
+                    self.follow_logs() # This will not return until pod completes
             elif self.state_is_terminated(status.state):
                 log.info('Handling terminated pod name {} with id {}'.format(pod.metadata.name, pod.metadata.uid))
                 container = self.get_first_or_none(pod.spec.containers)

--- a/tests/environment_variables.py
+++ b/tests/environment_variables.py
@@ -6,7 +6,7 @@ from typing import Optional
 @contextmanager
 def env_vars(**kwargs: Optional[str]):
     """
-    A context manager that temporarly changes environment variables. The call arguments their names are the names of
+    A context manager that temporarily changes environment variables. The call argument names are the names of
     the environment variables and the values are their value. As such the values are expected to be string if provided.
     A value of None signifies that the environment value must not exist.
     """

--- a/tests/environment_variables.py
+++ b/tests/environment_variables.py
@@ -1,0 +1,32 @@
+import os
+from contextlib import contextmanager
+from typing import Optional
+
+
+@contextmanager
+def env_vars(**kwargs: Optional[str]):
+    """
+    A context manager that temporarly changes environment variables. The call arguments their names are the names of
+    the environment variables and the values are their value. As such the values are expected to be string if provided.
+    A value of None signifies that the environment value must not exist.
+    """
+    backup_existing_environment: dict[str, Optional[str]] = {}
+    for k, v in kwargs.items():
+        assert v is None or isinstance(v, str), "Environment values must be of type str or set to None"
+    try:
+        for k, v in kwargs.items():
+            backup_existing_environment[k] = os.environ.get(k)
+            if v is None:
+                if k in os.environ:
+                    del os.environ[k]
+            else:
+                os.environ[k] = v
+        yield
+    finally:
+        # Restore the original values
+        for k, v in backup_existing_environment.items():
+            if v is None:
+                if k in os.environ:
+                    del os.environ[k]
+            else:
+                os.environ[k] = v

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -6,6 +6,7 @@ from kubernetes.config.config_exception import ConfigException
 from calrissian.executor import IncompleteStatusException
 from calrissian.k8s import load_config_get_namespace, KubernetesClient, CalrissianJobException, PodMonitor
 from calrissian.k8s import CompletionResult, read_file
+from tests.environment_variables import env_vars
 
 
 class ReadFileTestCase(TestCase):
@@ -240,19 +241,25 @@ class KubernetesClientTestCase(TestCase):
             mock_get_namespace.return_value, field_selector='metadata.name=mypod'
         )
 
-    @patch('calrissian.k8s.os')
-    def test_should_delete_pod_defaults_yes(self, mock_os, mock_get_namespace, mock_client):
-        mock_os.getenv.return_value = ''
-        kc = KubernetesClient()
-        self.assertTrue(kc.should_delete_pod())
-        self.assertEqual(mock_os.getenv.call_args, call('CALRISSIAN_DELETE_PODS', ''))
+    def test_should_delete_pod_defaults_yes(self, mock_get_namespace, mock_client):
+        with env_vars(CALRISSIAN_DELETE_PODS=None):
+            kc = KubernetesClient()
+            self.assertTrue(kc.should_delete_pod())
 
-    @patch('calrissian.k8s.os')
-    def test_should_delete_pod_reads_env(self, mock_os, mock_get_namespace, mock_client):
-        mock_os.getenv.return_value = 'NO'
-        kc = KubernetesClient()
-        self.assertFalse(kc.should_delete_pod())
-        self.assertEqual(mock_os.getenv.call_args, call('CALRISSIAN_DELETE_PODS', ''))
+    def test_should_delete_pod_reads_env(self, mock_get_namespace, mock_client):
+        with env_vars(CALRISSIAN_DELETE_PODS="NO"):
+            kc = KubernetesClient()
+            self.assertFalse(kc.should_delete_pod())
+
+    def test_should_stream_pod_logs_defaults_yes(self, mock_get_namespace, mock_client):
+        with env_vars(CALRISSIAN_STREAM_LOGS=None):
+            kc = KubernetesClient()
+            self.assertTrue(kc.should_stream_logs())
+
+    def test_should_stream_pod_logs__reads_env(self, mock_get_namespace, mock_client):
+        with env_vars(CALRISSIAN_STREAM_LOGS='NO'):
+            kc = KubernetesClient()
+            self.assertFalse(kc.should_stream_logs())
 
     def test_delete_pod_name_calls_api(self, mock_get_namespace, mock_client):
         kc = KubernetesClient()

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -256,7 +256,7 @@ class KubernetesClientTestCase(TestCase):
             kc = KubernetesClient()
             self.assertTrue(kc.should_stream_logs())
 
-    def test_should_stream_pod_logs__reads_env(self, mock_get_namespace, mock_client):
+    def test_should_stream_pod_logs_reads_env(self, mock_get_namespace, mock_client):
         with env_vars(CALRISSIAN_STREAM_LOGS='NO'):
             kc = KubernetesClient()
             self.assertFalse(kc.should_stream_logs())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,36 @@
+import os
+from unittest import TestCase
+from tests.environment_variables import env_vars
+
+
+class TestUtilsTestCase(TestCase):
+    def test_env_vars_context_can_temporarily_unset_environment_variable(self):
+        pp = os.environ.get("PATH")
+        self.assertIsNotNone(pp)
+        with env_vars(PATH=None):
+            self.assertIsNone(os.environ.get("PATH"))
+        self.assertEqual(pp, os.environ.get("PATH"))
+
+    def test_env_vars_context_can_temporarily_override_environment_variable(self):
+        pp = os.environ.get("PATH")
+        self.assertIsNotNone(pp)
+        override_value = "/non/existing/path"
+        with env_vars(PATH=override_value):
+            print(f"<environ>\n{os.environ}</environ>")
+
+            self.assertEqual(override_value, os.environ.get("PATH"))
+        self.assertEqual(pp, os.environ.get("PATH"))
+
+    def test_env_vars_context_can_temporarily_add_environment_variables(self):
+        test_var1 = "test_env_varname_1_non3xistan1"
+        test_var2 = "test_env_varname_2_non3xistan1"
+        test_value1 = "value1"
+        test_value2 = "value2"
+        self.assertIsNone(os.environ.get(test_var1))
+        self.assertIsNone(os.environ.get(test_var2))
+        with env_vars(test_env_varname_1_non3xistan1=test_value1, test_env_varname_2_non3xistan1= test_value2):
+            self.assertEqual(test_value1, os.environ.get(test_var1))
+            self.assertEqual(test_value2, os.environ.get(test_var2))
+
+        self.assertIsNone(os.environ.get(test_var1))
+        self.assertIsNone(os.environ.get(test_var2))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,8 +16,6 @@ class TestUtilsTestCase(TestCase):
         self.assertIsNotNone(pp)
         override_value = "/non/existing/path"
         with env_vars(PATH=override_value):
-            print(f"<environ>\n{os.environ}</environ>")
-
             self.assertEqual(override_value, os.environ.get("PATH"))
         self.assertEqual(pp, os.environ.get("PATH"))
 
@@ -28,7 +26,7 @@ class TestUtilsTestCase(TestCase):
         test_value2 = "value2"
         self.assertIsNone(os.environ.get(test_var1))
         self.assertIsNone(os.environ.get(test_var2))
-        with env_vars(test_env_varname_1_non3xistan1=test_value1, test_env_varname_2_non3xistan1= test_value2):
+        with env_vars(test_env_varname_1_non3xistan1=test_value1, test_env_varname_2_non3xistan1=test_value2):
             self.assertEqual(test_value1, os.environ.get(test_var1))
             self.assertEqual(test_value2, os.environ.get(test_var2))
 


### PR DESCRIPTION
When kubernetes is configured with a logshippers it is a convenient way to get pod logs with additional kubernetes context. It is especially powerful if structured logging is emitted. For such a setup it does not really provide value to stream back logs because it causes log duplication.

The default of streaming logs does make sense so this change just provides an opt-out mechanism using an environment variable similar to how one can opt-out of POD deletion.

To make sure to handle environment variables consistently a method was extracted and tests were refactored to not be tied to implementation detail (avoiding asserting how the mock is called)